### PR TITLE
Adds test for FX rates cache

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,9 +52,11 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	cachePath, _ := fx.HomeDirPath()
+
 	ok := app.RunAcbAppToConsole(
 		csvReaders, allInitStatus, options, legacyOptions,
-		&fx.CsvRatesCache{ErrPrinter: errPrinter}, errPrinter)
+		&fx.CsvRatesCache{ErrPrinter: errPrinter, Path: cachePath}, errPrinter)
 	if !ok {
 		os.Exit(1)
 	}

--- a/test/sample_files_test.go
+++ b/test/sample_files_test.go
@@ -13,7 +13,7 @@ import (
 	ptf "github.com/tsiemens/acb/portfolio"
 )
 
-func validateSampleCsvFile(rq *require.Assertions, csvPath string) {
+func validateSampleCsvFile(rq *require.Assertions, csvPath string, cachePath string) {
 	fp, err := os.Open(csvPath)
 	rq.Nil(err)
 	defer fp.Close()
@@ -22,10 +22,11 @@ func validateSampleCsvFile(rq *require.Assertions, csvPath string) {
 	errPrinter := &log.StderrErrorPrinter{}
 	_, err = app.RunAcbAppToRenderModel(
 		csvReaders, map[string]*ptf.PortfolioSecurityStatus{},
-		false, false,
+		false,
+		false,
 		app.LegacyOptions{},
 		// fx.NewMemRatesCacheAccessor(),
-		&fx.CsvRatesCache{ErrPrinter: errPrinter},
+		&fx.CsvRatesCache{ErrPrinter: errPrinter, Path: cachePath},
 		errPrinter,
 	)
 	rq.Nil(err)
@@ -41,6 +42,8 @@ func TestSampleCsvFileValidity(t *testing.T) {
 	// directory. This is what happens when running 'go test ./test'
 	rq.Regexp("test/?$", wd)
 
-	validateSampleCsvFile(rq, "./test_combined.csv")
-	validateSampleCsvFile(rq, "../www/html/sample_txs.csv")
+	tmpDir := t.TempDir()
+
+	validateSampleCsvFile(rq, "./test_combined.csv", tmpDir)
+	validateSampleCsvFile(rq, "../www/html/sample_txs.csv", tmpDir)
 }


### PR DESCRIPTION
Closes #23 - forgot to mention in https://github.com/tsiemens/acb/pull/22 that I was already trying to write a test for this just didn't want to get stuck on it. Turns out I was basically done, so here it is.

Refactors the `CsvRatesCache` to take a `Path` which allows tests to use a temp dir instead of the user's homedir.