### PR TITLE
acb: add tracking of total costs across all securities

### DIFF
--- a/app/approot.go
+++ b/app/approot.go
@@ -73,6 +73,7 @@ type Options struct {
 	RenderFullDollarValues  bool
 	SummaryModeLatestDate   date.Date
 	SplitAnnualSummaryGains bool
+	CSVOutputDir            string
 }
 
 func (o *Options) SummaryMode() bool {
@@ -85,6 +86,7 @@ func NewOptions() Options {
 		RenderFullDollarValues:  false,
 		SummaryModeLatestDate:   date.Date{},
 		SplitAnnualSummaryGains: false,
+		CSVOutputDir:            "",
 	}
 }
 
@@ -349,8 +351,18 @@ func RunAcbAppToConsole(
 			options, legacyOptions, ratesCache, errPrinter,
 		)
 	} else {
+		var writer outfmt.ACBWriter
+		if options.CSVOutputDir != "" {
+			var err error
+			if writer, err = outfmt.NewCSVWriter(options.CSVOutputDir); err != nil {
+				errPrinter.Ln(err)
+				return false
+			}
+		} else {
+			writer = outfmt.NewSTDWriter(os.Stdout)
+		}
 		ok, _ = RunAcbAppToWriter(
-			outfmt.NewSTDWriter(os.Stdout),
+			writer,
 			csvFileReaders, allInitStatus, options.ForceDownload, options.RenderFullDollarValues,
 			legacyOptions, ratesCache, errPrinter,
 		)

--- a/app/approot.go
+++ b/app/approot.go
@@ -73,6 +73,7 @@ type Options struct {
 	RenderFullDollarValues  bool
 	SummaryModeLatestDate   date.Date
 	SplitAnnualSummaryGains bool
+	RenderTotalCosts        bool
 	CSVOutputDir            string
 }
 
@@ -86,6 +87,7 @@ func NewOptions() Options {
 		RenderFullDollarValues:  false,
 		SummaryModeLatestDate:   date.Date{},
 		SplitAnnualSummaryGains: false,
+		RenderTotalCosts:        false,
 		CSVOutputDir:            "",
 	}
 }
@@ -157,6 +159,7 @@ func getCumulativeCapitalGains(deltasBySec map[string]*SecurityDeltas) *AllCumul
 type AppRenderResult struct {
 	SecurityTables      map[string]*ptf.RenderTable
 	AggregateGainsTable *ptf.RenderTable
+	CostsTables         *ptf.CostsTables
 }
 
 func RunAcbAppToRenderModel(
@@ -164,6 +167,7 @@ func RunAcbAppToRenderModel(
 	allInitStatus map[string]*ptf.PortfolioSecurityStatus,
 	forceDownload bool,
 	renderFullDollarValues bool,
+	renderTotalCosts bool,
 	legacyOptions LegacyOptions,
 	ratesCache fx.RatesCache,
 	errPrinter log.ErrorPrinter) (*AppRenderResult, error) {
@@ -177,8 +181,10 @@ func RunAcbAppToRenderModel(
 
 	gains := getCumulativeCapitalGains(deltasBySec)
 
+	var allDeltas []*ptf.TxDelta
 	secModels := make(map[string]*ptf.RenderTable)
 	for sec, deltas := range deltasBySec {
+		allDeltas = append(allDeltas, deltas.Deltas...)
 		tableModel := ptf.RenderTxTableModel(
 			deltas.Deltas, gains.SecurityGains[sec], renderFullDollarValues)
 		tableModel.Errors = deltas.Errors
@@ -188,7 +194,13 @@ func RunAcbAppToRenderModel(
 	cumulativeGainsTable := ptf.RenderAggregateCapitalGains(
 		gains.AggregateGains, renderFullDollarValues)
 
-	return &AppRenderResult{secModels, cumulativeGainsTable}, nil
+	result := &AppRenderResult{SecurityTables: secModels, AggregateGainsTable: cumulativeGainsTable}
+
+	if renderTotalCosts {
+		result.CostsTables = ptf.RenderTotalCosts(allDeltas, renderFullDollarValues)
+	}
+
+	return result, nil
 }
 
 func RunAcbAppSummaryToModel(
@@ -251,6 +263,16 @@ func WriteRenderResult(renderRes *AppRenderResult, writer outfmt.ACBWriter) erro
 		return fmt.Errorf("Rendering aggregate gains: %w", err)
 	}
 
+	if renderRes.CostsTables != nil {
+		if err := writer.PrintRenderTable(outfmt.Costs, "Total", renderRes.CostsTables.Total); err != nil {
+			return fmt.Errorf("Rendering total costs: %w", err)
+		}
+
+		if err := writer.PrintRenderTable(outfmt.Costs, "Yearly Max", renderRes.CostsTables.Yearly); err != nil {
+			return fmt.Errorf("Rendering yearly costs: %w", err)
+		}
+	}
+
 	if len(secsWithErrors) > 0 {
 		fmt.Println("\n[!] There are errors for the following securities:", strings.Join(secsWithErrors, ", "))
 	}
@@ -265,13 +287,14 @@ func RunAcbAppToWriter(
 	allInitStatus map[string]*ptf.PortfolioSecurityStatus,
 	forceDownload bool,
 	renderFullDollarValues bool,
+	renderTotalCosts bool,
 	legacyOptions LegacyOptions,
 	ratesCache fx.RatesCache,
 	errPrinter log.ErrorPrinter) (bool, *AppRenderResult) {
 
 	renderRes, err := RunAcbAppToRenderModel(
 		csvFileReaders, allInitStatus, forceDownload, renderFullDollarValues,
-		legacyOptions, ratesCache, errPrinter,
+		renderTotalCosts, legacyOptions, ratesCache, errPrinter,
 	)
 
 	if err != nil {
@@ -352,19 +375,21 @@ func RunAcbAppToConsole(
 		)
 	} else {
 		var writer outfmt.ACBWriter
+		renderCosts := options.RenderTotalCosts
 		if options.CSVOutputDir != "" {
 			var err error
 			if writer, err = outfmt.NewCSVWriter(options.CSVOutputDir); err != nil {
 				errPrinter.Ln(err)
 				return false
 			}
+			renderCosts = true
 		} else {
 			writer = outfmt.NewSTDWriter(os.Stdout)
 		}
 		ok, _ = RunAcbAppToWriter(
 			writer,
 			csvFileReaders, allInitStatus, options.ForceDownload, options.RenderFullDollarValues,
-			legacyOptions, ratesCache, errPrinter,
+			renderCosts, legacyOptions, ratesCache, errPrinter,
 		)
 	}
 	return ok

--- a/app/outfmt/csv.go
+++ b/app/outfmt/csv.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/tsiemens/acb/portfolio"
 )
@@ -21,6 +22,8 @@ func (w *CSVWriter) PrintRenderTable(outType OutputType, name string, tableModel
 		fn = fmt.Sprintf("%s.csv", name)
 	case AggregateGains:
 		fn = "aggregate-gains.csv"
+	case Costs:
+		fn = fmt.Sprintf("%s-costs.csv", strings.ReplaceAll(strings.ToLower(name), " ", "-"))
 	default:
 		return fmt.Errorf("OutputType %v not implemented", outType)
 	}

--- a/app/outfmt/csv.go
+++ b/app/outfmt/csv.go
@@ -1,0 +1,64 @@
+package outfmt
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/tsiemens/acb/portfolio"
+)
+
+type CSVWriter struct {
+	OutDir string
+}
+
+// PrintRenderTable implements ACBWriter.
+func (w *CSVWriter) PrintRenderTable(outType OutputType, name string, tableModel *portfolio.RenderTable) error {
+	var fn string
+	switch outType {
+	case Transactions:
+		fn = fmt.Sprintf("%s.csv", name)
+	case AggregateGains:
+		fn = "aggregate-gains.csv"
+	default:
+		return fmt.Errorf("OutputType %v not implemented", outType)
+	}
+
+	fp, err := os.Create(path.Join(w.OutDir, fn))
+	if err != nil {
+		return fmt.Errorf("Create file %q: %w", fn, err)
+	}
+	defer fp.Close()
+
+	csvWriter := csv.NewWriter(fp)
+
+	if err := csvWriter.Write(tableModel.Header); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	for _, row := range tableModel.Rows {
+		if err := csvWriter.Write(row); err != nil {
+			return fmt.Errorf("write row: %w", err)
+		}
+	}
+	if len(tableModel.Footer) > 0 {
+		if err := csvWriter.Write(tableModel.Footer); err != nil {
+			return fmt.Errorf("write footer: %w", err)
+		}
+	}
+	csvWriter.Flush()
+
+	for _, note := range tableModel.Notes {
+		fmt.Fprintln(fp, note)
+	}
+
+	return nil
+}
+
+func NewCSVWriter(outDir string) (*CSVWriter, error) {
+	if err := os.MkdirAll(outDir, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("Creating CSV output directory: %w", err)
+	}
+	return &CSVWriter{OutDir: outDir}, nil
+}

--- a/app/outfmt/model.go
+++ b/app/outfmt/model.go
@@ -9,6 +9,7 @@ type OutputType int
 const (
 	Transactions OutputType = iota
 	AggregateGains
+	Costs
 )
 
 type ACBWriter interface {

--- a/app/outfmt/std.go
+++ b/app/outfmt/std.go
@@ -38,6 +38,8 @@ func (w *STDWriter) PrintRenderTable(outType OutputType, name string, tableModel
 		title = fmt.Sprintf("Transactions for %s", name)
 	case AggregateGains:
 		title = "Aggregate Gains"
+	case Costs:
+		title = fmt.Sprintf("%s Costs", name)
 	default:
 		panic(fmt.Sprint("OutputType ", outType, " is not implemented"))
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -128,6 +128,8 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&options.SplitAnnualSummaryGains, "summarize-annual-gains", false,
 		"Summary will include transactions which represent annual capital gains/losses."+helpNl+
 			"Only valid with --summarize-before.")
+	RootCmd.PersistentFlags().BoolVar(&options.RenderTotalCosts, "total-costs", false,
+		"Print total costs across all securities")
 	RootCmd.PersistentFlags().StringVarP(&options.CSVOutputDir, "csv-output-dir", "d", "",
 		"Write output as CSV to the specified directory.")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,7 +129,7 @@ func init() {
 		"Summary will include transactions which represent annual capital gains/losses."+helpNl+
 			"Only valid with --summarize-before.")
 	RootCmd.PersistentFlags().BoolVar(&options.RenderTotalCosts, "total-costs", false,
-		"Print total costs across all securities")
+		"Print total costs across all securities (default, non-registered affiliate only)")
 	RootCmd.PersistentFlags().StringVarP(&options.CSVOutputDir, "csv-output-dir", "d", "",
 		"Write output as CSV to the specified directory.")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -128,6 +128,8 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&options.SplitAnnualSummaryGains, "summarize-annual-gains", false,
 		"Summary will include transactions which represent annual capital gains/losses."+helpNl+
 			"Only valid with --summarize-before.")
+	RootCmd.PersistentFlags().StringVarP(&options.CSVOutputDir, "csv-output-dir", "d", "",
+		"Write output as CSV to the specified directory.")
 
 	// Legacy Options (none currently)
 }

--- a/decimal_value/decimal_value.go
+++ b/decimal_value/decimal_value.go
@@ -49,6 +49,17 @@ func Abs(d DecimalOpt) DecimalOpt {
 	return DecimalOpt{Decimal: d.Decimal.Abs()}
 }
 
+func Max(d1, d2 DecimalOpt) DecimalOpt {
+	if d1.IsNull || d2.IsNull {
+		return Null
+	}
+
+	if d1.GreaterThan(d2) {
+		return d1
+	}
+	return d2
+}
+
 func (d DecimalOpt) Add(d2 DecimalOpt) DecimalOpt {
 	if d.IsNull || d2.IsNull {
 		return Null

--- a/portfolio/render.go
+++ b/portfolio/render.go
@@ -291,6 +291,10 @@ func RenderTotalCosts(allDeltas []*TxDelta, renderFullDollarValues bool) *CostsT
 			notes = append(notes, fmt.Sprintf("%v (%v) ignored transaction from registered affiliate",
 				dateFromDelta.String(), sec))
 			continue
+		} else if d.Tx.Affiliate != nil && !d.Tx.Affiliate.Default() {
+			notes = append(notes, fmt.Sprintf("%v (%v) ignored transaction from non-default affiliate %v",
+				dateFromDelta.String(), sec, d.Tx.Affiliate.Name()))
+			continue
 		}
 
 		if _, ok := dateCosts[dateFromDelta]; !ok {

--- a/test/acb_app_test.go
+++ b/test/acb_app_test.go
@@ -78,7 +78,7 @@ func TestSameDayBuySells(t *testing.T) {
 
 		renderRes, err := app.RunAcbAppToRenderModel(
 			csvReaders, map[string]*ptf.PortfolioSecurityStatus{},
-			false, false,
+			false, false, false,
 			app.LegacyOptions{},
 			fx.NewMemRatesCacheAccessor(),
 			&log.StderrErrorPrinter{},
@@ -101,7 +101,7 @@ func TestNegativeStocks(t *testing.T) {
 
 	renderRes, err := app.RunAcbAppToRenderModel(
 		csvReaders, map[string]*ptf.PortfolioSecurityStatus{},
-		false, false,
+		false, false, false,
 		app.LegacyOptions{},
 		fx.NewMemRatesCacheAccessor(),
 		&log.StderrErrorPrinter{},
@@ -125,7 +125,7 @@ func TestFractionalShares(t *testing.T) {
 
 	renderRes, err := app.RunAcbAppToRenderModel(
 		csvReaders, map[string]*ptf.PortfolioSecurityStatus{},
-		false, false,
+		false, false, false,
 		app.LegacyOptions{},
 		fx.NewMemRatesCacheAccessor(),
 		&log.StderrErrorPrinter{},
@@ -148,7 +148,7 @@ func TestSanitizedSecurityNames(t *testing.T) {
 
 	renderRes, err := app.RunAcbAppToRenderModel(
 		csvReaders, map[string]*ptf.PortfolioSecurityStatus{},
-		false, false,
+		false, false, false,
 		app.LegacyOptions{},
 		fx.NewMemRatesCacheAccessor(),
 		&log.StderrErrorPrinter{},

--- a/test/sample_files_test.go
+++ b/test/sample_files_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -13,7 +14,7 @@ import (
 	ptf "github.com/tsiemens/acb/portfolio"
 )
 
-func validateSampleCsvFile(rq *require.Assertions, csvPath string, cachePath string) {
+func validateSampleCsvFile(rq *require.Assertions, csvPath string, cachePath string, renderCosts bool) {
 	fp, err := os.Open(csvPath)
 	rq.Nil(err)
 	defer fp.Close()
@@ -24,7 +25,7 @@ func validateSampleCsvFile(rq *require.Assertions, csvPath string, cachePath str
 		csvReaders, map[string]*ptf.PortfolioSecurityStatus{},
 		false,
 		false,
-		false,
+		renderCosts,
 		app.LegacyOptions{},
 		// fx.NewMemRatesCacheAccessor(),
 		&fx.CsvRatesCache{ErrPrinter: errPrinter, Path: cachePath},
@@ -34,17 +35,22 @@ func validateSampleCsvFile(rq *require.Assertions, csvPath string, cachePath str
 }
 
 func TestSampleCsvFileValidity(t *testing.T) {
-	rq := require.New(t)
+	for _, renderCosts := range []bool{false, true} {
+		t.Run(fmt.Sprint("renderCosts=", renderCosts), func(t *testing.T) {
 
-	date.TodaysDateForTest = mkDateYD(2022, 1)
-	wd, err := os.Getwd()
-	rq.Nil(err)
-	// If running the compiled test binary manually, it must be run from the test
-	// directory. This is what happens when running 'go test ./test'
-	rq.Regexp("test/?$", wd)
+			rq := require.New(t)
 
-	tmpDir := t.TempDir()
+			date.TodaysDateForTest = mkDateYD(2022, 1)
+			wd, err := os.Getwd()
+			rq.Nil(err)
+			// If running the compiled test binary manually, it must be run from the test
+			// directory. This is what happens when running 'go test ./test'
+			rq.Regexp("test/?$", wd)
 
-	validateSampleCsvFile(rq, "./test_combined.csv", tmpDir)
-	validateSampleCsvFile(rq, "../www/html/sample_txs.csv", tmpDir)
+			tmpDir := t.TempDir()
+
+			validateSampleCsvFile(rq, "./test_combined.csv", tmpDir, renderCosts)
+			validateSampleCsvFile(rq, "../www/html/sample_txs.csv", tmpDir, renderCosts)
+		})
+	}
 }

--- a/test/sample_files_test.go
+++ b/test/sample_files_test.go
@@ -24,6 +24,7 @@ func validateSampleCsvFile(rq *require.Assertions, csvPath string, cachePath str
 		csvReaders, map[string]*ptf.PortfolioSecurityStatus{},
 		false,
 		false,
+		false,
 		app.LegacyOptions{},
 		// fx.NewMemRatesCacheAccessor(),
 		&fx.CsvRatesCache{ErrPrinter: errPrinter, Path: cachePath},

--- a/test/total_cost_test.go
+++ b/test/total_cost_test.go
@@ -1,0 +1,166 @@
+package test
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tsiemens/acb/app/outfmt"
+	"github.com/tsiemens/acb/date"
+	"github.com/tsiemens/acb/decimal_value"
+	ptf "github.com/tsiemens/acb/portfolio"
+)
+
+type td struct {
+	Sec      string
+	Settle   string
+	TotalAcb string
+}
+
+func getDelta(td *td) (*ptf.TxDelta, error) {
+	settle, err := date.Parse(date.DefaultFormat, td.Settle)
+	if err != nil {
+		return nil, fmt.Errorf("date %v: %w", td.Settle, err)
+	}
+
+	acb, err := decimal_value.NewFromString(td.TotalAcb)
+	if err != nil {
+		return nil, fmt.Errorf("TotalAcb %v: %w", td.TotalAcb, err)
+	}
+
+	return &ptf.TxDelta{
+		Tx: &ptf.Tx{
+			Security:       td.Sec,
+			SettlementDate: settle,
+		},
+		PostStatus: &ptf.PortfolioSecurityStatus{
+			Security: td.Sec,
+			TotalAcb: acb,
+		},
+	}, nil
+}
+
+func getDeltas(v []*td) (ret []*ptf.TxDelta, _ error) {
+	for _, i := range v {
+		d, err := getDelta(i)
+		if err != nil {
+			return nil, fmt.Errorf("getDelta %v: %w", i, err)
+		}
+		ret = append(ret, d)
+	}
+	return ret, nil
+}
+
+func renderTable(rq *require.Assertions, rt *ptf.RenderTable) string {
+	b := &strings.Builder{}
+	wr := outfmt.NewSTDWriter(b)
+	rq.NoError(wr.PrintRenderTable(outfmt.Costs, "Table of", rt))
+	return b.String()
+}
+
+func fixupRows(startidx int, v [][]string) {
+	for i, r := range v {
+		for j := startidx; j < len(r); j++ {
+			c := strings.TrimSpace(r[j])
+			v[i][j] = "$" + decimal_value.RequireFromString(c).StringFixed(2)
+		}
+	}
+}
+func TestRenderTotalCosts(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reorg func(data []*td)
+	}{
+		{
+			name:  "none",
+			reorg: func(data []*td) {},
+		},
+		{
+			name: "by-security",
+			reorg: func(data []*td) {
+				sort.SliceStable(data, func(i, j int) bool {
+					return data[i].Sec < data[j].Sec
+				})
+			},
+		},
+		{
+			name: "reverse",
+			reorg: func(data []*td) {
+				for i, j := 0, len(data)-1; i < j; i, j = i+1, j-1 {
+					data[i], data[j] = data[j], data[i]
+				}
+			},
+		},
+		{
+			name: "by-acb-sec",
+			reorg: func(data []*td) {
+				sort.SliceStable(data, func(i, j int) bool {
+					ii := decimal_value.RequireFromString(data[i].TotalAcb)
+					jj := decimal_value.RequireFromString(data[j].TotalAcb)
+					if !ii.Equal(jj) {
+						return ii.LessThan(jj)
+					}
+					return data[i].Sec < data[j].Sec
+				})
+			},
+		},
+	} {
+		t.Run(fmt.Sprint("reorg:", tc.name), func(t *testing.T) {
+			data := []*td{
+				{Sec: "SECA", Settle: "2001-01-13", TotalAcb: "100"},
+				{Sec: "XXXX", Settle: "2001-02-14", TotalAcb: "90"},
+				{Sec: "SECA", Settle: "2001-03-15", TotalAcb: "0"},
+				{Sec: "XXXX", Settle: "2001-04-16", TotalAcb: "80"},
+				{Sec: "SECA", Settle: "2001-05-17", TotalAcb: "200"},
+				{Sec: "XXXX", Settle: "2001-05-17", TotalAcb: "70"},
+				{Sec: "SECA", Settle: "2003-01-01", TotalAcb: "0"},
+				{Sec: "SECA", Settle: "2003-01-02", TotalAcb: "150"},
+				{Sec: "XXXX", Settle: "2003-01-02", TotalAcb: "35"},
+				{Sec: "SECA", Settle: "2003-01-03", TotalAcb: "0"},
+			}
+			tc.reorg(data)
+
+			for _, d := range data {
+				t.Log(d)
+			}
+
+			rq := require.New(t)
+			allDeltas, err := getDeltas(data)
+			rq.NoError(err)
+			costs := ptf.RenderTotalCosts(allDeltas, false)
+
+			exp := &ptf.RenderTable{
+				Header: []string{"Date", "Total", "SECA", "XXXX"},
+				Rows: [][]string{
+					{"2001-01-13", "100", "100", " 0"},
+					{"2001-02-14", "190", "100", "90"},
+					{"2001-03-15", " 90", "  0", "90"},
+					{"2001-04-16", " 80", "  0", "80"},
+					{"2001-05-17", "270", "200", "70"},
+					{"2003-01-01", " 70", "  0", "70"},
+					{"2003-01-02", "185", "150", "35"},
+					{"2003-01-03", " 35", "  0", "35"},
+				},
+			}
+			fixupRows(1, exp.Rows)
+
+			actual := renderTable(rq, costs.Total)
+			t.Log("\n" + actual)
+			rq.Equal(renderTable(rq, exp), actual)
+
+			expYear := &ptf.RenderTable{
+				Header: []string{"Year", "Date", "Total", "SECA", "XXXX"},
+				Rows: [][]string{
+					{"2001", "2001-05-17", "270", "200", "70"},
+					{"2003", "2003-01-02", "185", "150", "35"},
+				},
+			}
+			fixupRows(2, expYear.Rows)
+			yearActual := renderTable(rq, costs.Yearly)
+			t.Log("\n" + yearActual)
+			rq.Equal(renderTable(rq, expYear), yearActual)
+		})
+	}
+}

--- a/www/wasm/main.go
+++ b/www/wasm/main.go
@@ -127,6 +127,7 @@ func runAcb(
 	csvDescs []string, csvContents []string,
 	initialSymbolStates []string,
 	renderFullValues bool,
+	renderCosts bool,
 	// Legacy options (none currently)
 ) (js.Value, error) {
 
@@ -152,7 +153,7 @@ func runAcb(
 
 	ok, renderRes := app.RunAcbAppToWriter(
 		writer,
-		csvReaders, allInitStatus, forceDownload, renderFullValues,
+		csvReaders, allInitStatus, forceDownload, renderFullValues, renderCosts,
 		legacyOptions, &fx.MemRatesCacheAccessor{RatesByYear: globalRatesCache},
 		errPrinter,
 	)
@@ -284,12 +285,13 @@ func makeRunAcbWrapper() js.Func {
 		}
 
 		renderFullValues := popArg().Bool()
+		renderCosts := false
 
 		promise := makeJsPromise(
 			func(resolveFunc js.Value, rejectFunc js.Value) {
 				go func() {
 					out, err := runAcb(
-						descs, contents, initialSymbolStates, renderFullValues)
+						descs, contents, initialSymbolStates, renderFullValues, renderCosts)
 					resolveFunc.Invoke(makeRetVal(out, err))
 					// rejectFunc.Invoke("something error")
 				}()


### PR DESCRIPTION
This keeps track of the total cost basis across all securities for every day where any trades have been made. It will also use this information to present a yearly summary of the maximum cost of all tracked securities in aggregate. This is useful in determining if, for example, a T1135 form will be required for a given year.

Since it now generates multiple reports, there's a new --csv-output-dir that will cause all of the reports to be written to separate CSV files in the specified directory for easier consumption.

A new test, test/total_cost_test.go, checks the correctness of the aggregate cost reporting.