### PR TITLE
chore: simplify code using automated refactoring tools

### DIFF
--- a/app/approot.go
+++ b/app/approot.go
@@ -214,7 +214,7 @@ func RunAcbAppSummaryToModel(
 		deltasBySec[sec] = deltas.Deltas
 	}
 	if len(errors) > 0 {
-		return &ptf.CollectedSummaryData{nil, nil, errors}, nil
+		return &ptf.CollectedSummaryData{Txs: nil, Warnings: nil, Errors: errors}, nil
 	}
 
 	return ptf.MakeAggregateSummaryTxs(latestDate, deltasBySec, options.SplitAnnualSummaryGains), nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,7 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 		defer fp.Close()
-		csvReaders = append(csvReaders, app.DescribedReader{csvName, fp})
+		csvReaders = append(csvReaders, app.DescribedReader{Desc: csvName, Reader: fp})
 	}
 
 	if summarizeBeforeStr != "" {

--- a/portfolio/cumulative_gains.go
+++ b/portfolio/cumulative_gains.go
@@ -20,7 +20,7 @@ func (g *CumulativeCapitalGains) CapitalGainsYearTotalsKeysSorted() []int {
 
 func CalcSecurityCumulativeCapitalGains(deltas []*TxDelta) *CumulativeCapitalGains {
 	var capGainsTotal decimal_opt.DecimalOpt
-	capGainsYearTotals := util.NewDefaultMap[int, decimal_opt.DecimalOpt](
+	capGainsYearTotals := util.NewDefaultMap(
 		func(_ int) decimal_opt.DecimalOpt { return decimal_opt.Zero })
 
 	for _, d := range deltas {
@@ -36,7 +36,7 @@ func CalcSecurityCumulativeCapitalGains(deltas []*TxDelta) *CumulativeCapitalGai
 
 func CalcCumulativeCapitalGains(secGains map[string]*CumulativeCapitalGains) *CumulativeCapitalGains {
 	var capGainsTotal decimal_opt.DecimalOpt
-	capGainsYearTotals := util.NewDefaultMap[int, decimal_opt.DecimalOpt](
+	capGainsYearTotals := util.NewDefaultMap(
 		func(_ int) decimal_opt.DecimalOpt { return decimal_opt.Zero })
 
 	for _, gains := range secGains {

--- a/portfolio/io.go
+++ b/portfolio/io.go
@@ -44,7 +44,7 @@ var ColNames []string
 
 func init() {
 	ColNames = make([]string, 0, len(colParserMap))
-	for name, _ := range colParserMap {
+	for name := range colParserMap {
 		ColNames = append(ColNames, name)
 	}
 }

--- a/portfolio/render.go
+++ b/portfolio/render.go
@@ -112,7 +112,7 @@ func RenderTxTableModel(
 			superficialLossAsterix = fmt.Sprintf(
 				" *\n(SfL %s%s; %s/%s%s)",
 				ph.PlusMinusDollar(d.SuperficialLoss, false),
-				util.Tern[string](specifiedSflIsForced, "!", ""),
+				util.Tern(specifiedSflIsForced, "!", ""),
 				d.SuperficialLossRatio.Numerator,
 				d.SuperficialLossRatio.Denominator,
 				extraSflNoteStr,

--- a/portfolio/render.go
+++ b/portfolio/render.go
@@ -193,12 +193,12 @@ func RenderTxTableModel(
 }
 
 /*
-  Generates a RenderTable that will render out to this:
-  | Year             | Capital Gains |
-  +------------------+---------------+
-  | 2000             | xxxx.xx       |
-  | 2001             | xxxx.xx       |
-  | Since inception  | xxxx.xx       |
+Generates a RenderTable that will render out to this:
+| Year             | Capital Gains |
++------------------+---------------+
+| 2000             | xxxx.xx       |
+| 2001             | xxxx.xx       |
+| Since inception  | xxxx.xx       |
 */
 func RenderAggregateCapitalGains(
 	gains *CumulativeCapitalGains, renderFullDollarValues bool) *RenderTable {

--- a/portfolio/summary.go
+++ b/portfolio/summary.go
@@ -265,7 +265,7 @@ func makeAnnualGainsSummaryTxs(
 	}
 
 	yearsWithGains := make([]int, 0, len(yearlyCapGains))
-	for year, _ := range yearlyCapGains {
+	for year := range yearlyCapGains {
 		yearsWithGains = append(yearsWithGains, year)
 	}
 	sort.Ints(yearsWithGains)

--- a/portfolio/summary.go
+++ b/portfolio/summary.go
@@ -215,7 +215,7 @@ func makeSimpleSummaryTxs(
 				SettlementDate: tx.SettlementDate,
 				Action:         BUY,
 				Shares:         sumPostStatus.ShareBalance,
-				AmountPerShare: util.Tern[decimal.Decimal](
+				AmountPerShare: util.Tern(
 					sumPostStatus.TotalAcb.IsNull, decimal.Zero, sumPostStatus.TotalAcb.DivD(sumPostStatus.ShareBalance).Decimal),
 				Commission: decimal.Zero,
 				TxCurrency: DEFAULT_CURRENCY, TxCurrToLocalExchangeRate: decimal.Zero,
@@ -295,7 +295,7 @@ func makeAnnualGainsSummaryTxs(
 			SettlementDate: dt,
 			Action:         BUY,
 			Shares:         nBaseShares,
-			AmountPerShare: util.Tern[decimal.Decimal](baseAcbPerShare.IsNull, decimal.Zero, baseAcbPerShare.Decimal),
+			AmountPerShare: util.Tern(baseAcbPerShare.IsNull, decimal.Zero, baseAcbPerShare.Decimal),
 			Commission:     decimal.Zero,
 			TxCurrency:     DEFAULT_CURRENCY, TxCurrToLocalExchangeRate: decimal.Zero,
 			CommissionCurrency: DEFAULT_CURRENCY, CommissionCurrToLocalExchangeRate: decimal.Zero,

--- a/test/acb_app_test.go
+++ b/test/acb_app_test.go
@@ -28,7 +28,7 @@ func makeCsvReader(desc string, lines ...string) app.DescribedReader {
 	} else {
 		headerToUse = header
 	}
-	return app.DescribedReader{desc, strings.NewReader(headerToUse + contents)}
+	return app.DescribedReader{Desc: desc, Reader: strings.NewReader(headerToUse + contents)}
 }
 
 func render(tableModel *ptf.RenderTable) {

--- a/test/acb_app_test.go
+++ b/test/acb_app_test.go
@@ -66,7 +66,7 @@ func getAndCheckFooTable(rq *require.Assertions, rts map[string]*ptf.RenderTable
 func TestSameDayBuySells(t *testing.T) {
 	rq := require.New(t)
 
-	for _, splits := range [][]uint32{[]uint32{3}, []uint32{1, 2}} {
+	for _, splits := range [][]uint32{{3}, {1, 2}} {
 		csvReaders := splitCsvRows(splits,
 			"FOO,2016-01-03,2016-01-05,Buy,20,1.5,CAD,,0,,,",
 			"FOO,2016-01-03,2016-01-05,Sell,5,1.6,CAD,,0,,,",

--- a/test/acb_summary_test.go
+++ b/test/acb_summary_test.go
@@ -285,11 +285,11 @@ func TestSummary(t *testing.T) {
 	}
 	expSummaryTxs = []*ptf.Tx{
 		TSimpleSumTx{Year: 2022, DoY: -70, Shares: DInt(8), Amount: DFlt(1.45)}.X(),
-		TTx{SYr: 2022, SDoY: -45, Act: ptf.BUY, Shares: DInt(8), Price: DInt(1), Comm: DInt(2)}.X(),                                    // post ACB = 21.6
-		TTx{SYr: 2022, SDoY: -31, Act: ptf.BUY, Shares: DInt(2), Price: DInt(1), Comm: DInt(2)}.X(),                                    // post ACB = 25.6
+		TTx{SYr: 2022, SDoY: -45, Act: ptf.BUY, Shares: DInt(8), Price: DInt(1), Comm: DInt(2)}.X(),                                      // post ACB = 21.6
+		TTx{SYr: 2022, SDoY: -31, Act: ptf.BUY, Shares: DInt(2), Price: DInt(1), Comm: DInt(2)}.X(),                                      // post ACB = 25.6
 		TTx{SYr: 2022, SDoY: -15, Act: ptf.SELL, Shares: DInt(2), Price: DFlt(0.2), SFL: CADSFL(DStr("-2.4444444444444444"), false)}.X(), // ACB = 22.755555556
-		makeSflaTxYD(2022, -15, DStr("2.4444444444444444")),                                                                            // ACB of 25.2
-		TTx{SYr: 2022, SDoY: -1, Act: ptf.SELL, Shares: DInt(2), Price: DFlt(0.2), SFL: CADSFL(DStr("-2.75"), false)}.X(),  // ACB = 22.05
+		makeSflaTxYD(2022, -15, DStr("2.4444444444444444")),                                                                              // ACB of 25.2
+		TTx{SYr: 2022, SDoY: -1, Act: ptf.SELL, Shares: DInt(2), Price: DFlt(0.2), SFL: CADSFL(DStr("-2.75"), false)}.X(),                // ACB = 22.05
 		makeSflaTxYD(2022, -1, DFlt(2.75)),
 	}
 

--- a/test/fx_io_test.go
+++ b/test/fx_io_test.go
@@ -61,9 +61,9 @@ func TestFillInUnknownDayRates(t *testing.T) {
 	crq := NewCustomRequire(t)
 
 	rates := []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-		fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-		fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
+		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+		{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
 	}
 
 	// Simple no fills
@@ -71,9 +71,9 @@ func TestFillInUnknownDayRates(t *testing.T) {
 	crq.Equal(
 		fx.FillInUnknownDayRates(rates, 2022),
 		[]fx.DailyRate{
-			fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-			fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
+			{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+			{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
 		},
 	)
 
@@ -81,9 +81,9 @@ func TestFillInUnknownDayRates(t *testing.T) {
 	crq.Equal(
 		fx.FillInUnknownDayRates(rates, 2022),
 		[]fx.DailyRate{
-			fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-			fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
+			{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+			{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
 		},
 	)
 
@@ -92,10 +92,10 @@ func TestFillInUnknownDayRates(t *testing.T) {
 	crq.Equal(
 		fx.FillInUnknownDayRates(rates, 2022),
 		[]fx.DailyRate{
-			fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-			fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
-			fx.DailyRate{mkDateYD(2022, 3), decimal.Zero},
+			{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+			{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
+			{mkDateYD(2022, 3), decimal.Zero},
 		},
 	)
 
@@ -109,27 +109,27 @@ func TestFillInUnknownDayRates(t *testing.T) {
 	// Middle and front fills
 	rates = []fx.DailyRate{
 		// fx.DailyRate{mkDateYD(2022, 0), 1.0},
-		fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
 		// fx.DailyRate{mkDateYD(2022, 2), 1.2},
-		fx.DailyRate{mkDateYD(2022, 3), decimal.NewFromFloat(1.3)},
-		fx.DailyRate{mkDateYD(2022, 4), decimal.NewFromFloat(1.4)},
+		{mkDateYD(2022, 3), decimal.NewFromFloat(1.3)},
+		{mkDateYD(2022, 4), decimal.NewFromFloat(1.4)},
 		// fx.DailyRate{mkDateYD(2022, 5), 1.2},
 		// fx.DailyRate{mkDateYD(2022, 6), 1.2},
-		fx.DailyRate{mkDateYD(2022, 7), decimal.NewFromFloat(1.7)},
+		{mkDateYD(2022, 7), decimal.NewFromFloat(1.7)},
 	}
 
 	date.TodaysDateForTest = mkDateYD(2022, 7)
 	crq.Equal(
 		fx.FillInUnknownDayRates(rates, 2022),
 		[]fx.DailyRate{
-			fx.DailyRate{mkDateYD(2022, 0), decimal.Zero},
-			fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			fx.DailyRate{mkDateYD(2022, 2), decimal.Zero},
-			fx.DailyRate{mkDateYD(2022, 3), decimal.NewFromFloat(1.3)},
-			fx.DailyRate{mkDateYD(2022, 4), decimal.NewFromFloat(1.4)},
-			fx.DailyRate{mkDateYD(2022, 5), decimal.Zero},
-			fx.DailyRate{mkDateYD(2022, 6), decimal.Zero},
-			fx.DailyRate{mkDateYD(2022, 7), decimal.NewFromFloat(1.7)},
+			{mkDateYD(2022, 0), decimal.Zero},
+			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+			{mkDateYD(2022, 2), decimal.Zero},
+			{mkDateYD(2022, 3), decimal.NewFromFloat(1.3)},
+			{mkDateYD(2022, 4), decimal.NewFromFloat(1.4)},
+			{mkDateYD(2022, 5), decimal.Zero},
+			{mkDateYD(2022, 6), decimal.Zero},
+			{mkDateYD(2022, 7), decimal.NewFromFloat(1.7)},
 		},
 	)
 
@@ -144,11 +144,11 @@ func TestGetEffectiveUsdCadRateFreshCache(t *testing.T) {
 	rateLoader, ratesCache, remote := NewTestRateLoader(false)
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{}
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
 		// fx.DailyRate{mkDateYD(2022, 1), 1.1}, // Expect fill here
-		fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
+		{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
 		// Expect 9 days fill here (unrealistic)
-		fx.DailyRate{mkDateYD(2022, 12), decimal.NewFromFloat(2.2)},
+		{mkDateYD(2022, 12), decimal.NewFromFloat(2.2)},
 	}
 
 	// Test failure to get from remote.
@@ -221,9 +221,9 @@ func TestGetEffectiveUsdCadRateWithCache(t *testing.T) {
 
 	rateLoader, ratesCache, _ := NewTestRateLoader(false)
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-		fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(0.0)}, // Filled (markets closed)
-		fx.DailyRate{mkDateYD(2022, 3), decimal.NewFromFloat(0.0)}, // Filled (markets closed)
+		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+		{mkDateYD(2022, 2), decimal.NewFromFloat(0.0)}, // Filled (markets closed)
+		{mkDateYD(2022, 3), decimal.NewFromFloat(0.0)}, // Filled (markets closed)
 	}
 
 	// Test lookup of well-known cached value for tomorrow, today, yesterday
@@ -259,17 +259,17 @@ func TestGetEffectiveUsdCadRateCacheInvalidation(t *testing.T) {
 	// no remote value
 	rateLoader, ratesCache, remote := NewTestRateLoader(false)
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
 	}
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.4)}, // Value change.
+		{mkDateYD(2022, 1), decimal.NewFromFloat(1.4)}, // Value change.
 	}
 	date.TodaysDateForTest = mkDateYD(2022, 2)
 	_, err := rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 2))
 	crq.Equal(ratesCache.RatesByYear[2022],
 		[]fx.DailyRate{
-			fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(0.0)}, // fill
-			fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.4)},
+			{mkDateYD(2022, 0), decimal.NewFromFloat(0.0)}, // fill
+			{mkDateYD(2022, 1), decimal.NewFromFloat(1.4)},
 		})
 	rq.NotNil(err) // Can't use today unless it's been published or specified.
 
@@ -277,11 +277,11 @@ func TestGetEffectiveUsdCadRateCacheInvalidation(t *testing.T) {
 	// a remote value
 	rateLoader, ratesCache, remote = NewTestRateLoader(false)
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
 	}
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-		fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
 	}
 	date.TodaysDateForTest = mkDateYD(2022, 1)
 	rate, err := rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 1))
@@ -292,38 +292,38 @@ func TestGetEffectiveUsdCadRateCacheInvalidation(t *testing.T) {
 	// Test cache invalidates when querying a previous day with no cached value.
 	rateLoader, ratesCache, remote = NewTestRateLoader(false)
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
 	}
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-		fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
 	}
 	date.TodaysDateForTest = mkDateYD(2022, 4)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 1))
 	rq.Nil(err)
 	crq.Equal(ratesCache.RatesByYear[2022],
 		[]fx.DailyRate{
-			fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-			fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(0.0)}, // fill to yesterday
-			fx.DailyRate{mkDateYD(2022, 3), decimal.NewFromFloat(0.0)}, // fill to yesterday
+			{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+			{mkDateYD(2022, 2), decimal.NewFromFloat(0.0)}, // fill to yesterday
+			{mkDateYD(2022, 3), decimal.NewFromFloat(0.0)}, // fill to yesterday
 		})
 	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)})
 
 	// Test cache does not invalidate when querying today with no cached value,
 	// after we already invalidated and refreshed the cache with this Loader instance.
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(99.0)},
-		fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(99.1)},
+		{mkDateYD(2022, 0), decimal.NewFromFloat(99.0)},
+		{mkDateYD(2022, 1), decimal.NewFromFloat(99.1)},
 	}
 	_, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 4))
 	// Cache should be unchanged
 	crq.Equal(ratesCache.RatesByYear[2022],
 		[]fx.DailyRate{
-			fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-			fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(0.0)},
-			fx.DailyRate{mkDateYD(2022, 3), decimal.NewFromFloat(0.0)},
+			{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+			{mkDateYD(2022, 2), decimal.NewFromFloat(0.0)},
+			{mkDateYD(2022, 3), decimal.NewFromFloat(0.0)},
 		})
 	rq.NotNil(err) // Can't use today unless it's been published or specified.
 
@@ -331,10 +331,10 @@ func TestGetEffectiveUsdCadRateCacheInvalidation(t *testing.T) {
 	rateLoader, ratesCache, remote = NewTestRateLoader(false)
 	rateLoader.ForceDownload = true
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
 	}
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(99.0)},
+		{mkDateYD(2022, 0), decimal.NewFromFloat(99.0)},
 	}
 	date.TodaysDateForTest = mkDateYD(2022, 1)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 0))
@@ -364,7 +364,7 @@ func TestGetEffectiveUsdCadRateWithCsvCache(t *testing.T) {
 	}
 
 	remoteLoader.RemoteYearRates[2022] = []fx.DailyRate{
-		fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.2)},
+		{mkDateYD(2022, 1), decimal.NewFromFloat(1.2)},
 	}
 
 	// fetch mocked remote values and write to cache

--- a/test/fx_io_test.go
+++ b/test/fx_io_test.go
@@ -61,9 +61,9 @@ func TestFillInUnknownDayRates(t *testing.T) {
 	crq := NewCustomRequire(t)
 
 	rates := []fx.DailyRate{
-		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-		{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
+		{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
+		{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
+		{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(1.2)},
 	}
 
 	// Simple no fills
@@ -71,9 +71,9 @@ func TestFillInUnknownDayRates(t *testing.T) {
 	crq.Equal(
 		fx.FillInUnknownDayRates(rates, 2022),
 		[]fx.DailyRate{
-			{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
+			{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
+			{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
+			{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(1.2)},
 		},
 	)
 
@@ -81,9 +81,9 @@ func TestFillInUnknownDayRates(t *testing.T) {
 	crq.Equal(
 		fx.FillInUnknownDayRates(rates, 2022),
 		[]fx.DailyRate{
-			{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
+			{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
+			{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
+			{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(1.2)},
 		},
 	)
 
@@ -92,10 +92,10 @@ func TestFillInUnknownDayRates(t *testing.T) {
 	crq.Equal(
 		fx.FillInUnknownDayRates(rates, 2022),
 		[]fx.DailyRate{
-			{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
-			{mkDateYD(2022, 3), decimal.Zero},
+			{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
+			{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
+			{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(1.2)},
+			{Date: mkDateYD(2022, 3), ForeignToLocalRate: decimal.Zero},
 		},
 	)
 
@@ -109,27 +109,27 @@ func TestFillInUnknownDayRates(t *testing.T) {
 	// Middle and front fills
 	rates = []fx.DailyRate{
 		// fx.DailyRate{mkDateYD(2022, 0), 1.0},
-		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+		{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
 		// fx.DailyRate{mkDateYD(2022, 2), 1.2},
-		{mkDateYD(2022, 3), decimal.NewFromFloat(1.3)},
-		{mkDateYD(2022, 4), decimal.NewFromFloat(1.4)},
+		{Date: mkDateYD(2022, 3), ForeignToLocalRate: decimal.NewFromFloat(1.3)},
+		{Date: mkDateYD(2022, 4), ForeignToLocalRate: decimal.NewFromFloat(1.4)},
 		// fx.DailyRate{mkDateYD(2022, 5), 1.2},
 		// fx.DailyRate{mkDateYD(2022, 6), 1.2},
-		{mkDateYD(2022, 7), decimal.NewFromFloat(1.7)},
+		{Date: mkDateYD(2022, 7), ForeignToLocalRate: decimal.NewFromFloat(1.7)},
 	}
 
 	date.TodaysDateForTest = mkDateYD(2022, 7)
 	crq.Equal(
 		fx.FillInUnknownDayRates(rates, 2022),
 		[]fx.DailyRate{
-			{mkDateYD(2022, 0), decimal.Zero},
-			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			{mkDateYD(2022, 2), decimal.Zero},
-			{mkDateYD(2022, 3), decimal.NewFromFloat(1.3)},
-			{mkDateYD(2022, 4), decimal.NewFromFloat(1.4)},
-			{mkDateYD(2022, 5), decimal.Zero},
-			{mkDateYD(2022, 6), decimal.Zero},
-			{mkDateYD(2022, 7), decimal.NewFromFloat(1.7)},
+			{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.Zero},
+			{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
+			{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.Zero},
+			{Date: mkDateYD(2022, 3), ForeignToLocalRate: decimal.NewFromFloat(1.3)},
+			{Date: mkDateYD(2022, 4), ForeignToLocalRate: decimal.NewFromFloat(1.4)},
+			{Date: mkDateYD(2022, 5), ForeignToLocalRate: decimal.Zero},
+			{Date: mkDateYD(2022, 6), ForeignToLocalRate: decimal.Zero},
+			{Date: mkDateYD(2022, 7), ForeignToLocalRate: decimal.NewFromFloat(1.7)},
 		},
 	)
 
@@ -144,11 +144,11 @@ func TestGetEffectiveUsdCadRateFreshCache(t *testing.T) {
 	rateLoader, ratesCache, remote := NewTestRateLoader(false)
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{}
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
 		// fx.DailyRate{mkDateYD(2022, 1), 1.1}, // Expect fill here
-		{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)},
+		{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(1.2)},
 		// Expect 9 days fill here (unrealistic)
-		{mkDateYD(2022, 12), decimal.NewFromFloat(2.2)},
+		{Date: mkDateYD(2022, 12), ForeignToLocalRate: decimal.NewFromFloat(2.2)},
 	}
 
 	// Test failure to get from remote.
@@ -160,27 +160,27 @@ func TestGetEffectiveUsdCadRateFreshCache(t *testing.T) {
 	rateLoader, ratesCache = NewTestRateLoaderWithRemote(false, remote)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 0))
 	rq.Nil(err)
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)})
 	// Test fall back to previous day rate
 	rateLoader, ratesCache = NewTestRateLoaderWithRemote(false, remote)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 1))
 	rq.Nil(err)
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)})
 	// Test exact match after a fill day
 	rateLoader, ratesCache = NewTestRateLoaderWithRemote(false, remote)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 2))
 	rq.Nil(err)
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(1.2)})
 	// Test fall back with the day ahead also not being present
 	rateLoader, ratesCache = NewTestRateLoaderWithRemote(false, remote)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 7))
 	rq.Nil(err)
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(1.2)})
 	// Test fall back 7 days (the max allowed)
 	rateLoader, ratesCache = NewTestRateLoaderWithRemote(false, remote)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 9))
 	rq.Nil(err)
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 2), decimal.NewFromFloat(1.2)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(1.2)})
 	// Test fall back 8 days (more than allowed)
 	rateLoader, ratesCache = NewTestRateLoaderWithRemote(false, remote)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 10))
@@ -191,7 +191,7 @@ func TestGetEffectiveUsdCadRateFreshCache(t *testing.T) {
 	rateLoader, ratesCache = NewTestRateLoaderWithRemote(false, remote)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 12))
 	rq.Nil(err)
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 12), decimal.NewFromFloat(2.2)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 12), ForeignToLocalRate: decimal.NewFromFloat(2.2)})
 
 	// Test lookup for today's (undetermined) rate
 	date.TodaysDateForTest = mkDateYD(2022, 13)
@@ -207,7 +207,7 @@ func TestGetEffectiveUsdCadRateFreshCache(t *testing.T) {
 	rateLoader, ratesCache = NewTestRateLoaderWithRemote(false, remote)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 13))
 	rq.Nil(err)
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 12), decimal.NewFromFloat(2.2)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 12), ForeignToLocalRate: decimal.NewFromFloat(2.2)})
 }
 
 func TestGetEffectiveUsdCadRateWithCache(t *testing.T) {
@@ -216,14 +216,14 @@ func TestGetEffectiveUsdCadRateWithCache(t *testing.T) {
 
 	// Sanity check
 	rq.True(
-		fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(0.0)}.Equal(
-			fx.DailyRate{mkDateYD(2022, 1), decimal.Zero}))
+		fx.DailyRate{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(0.0)}.Equal(
+			fx.DailyRate{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.Zero}))
 
 	rateLoader, ratesCache, _ := NewTestRateLoader(false)
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-		{mkDateYD(2022, 2), decimal.NewFromFloat(0.0)}, // Filled (markets closed)
-		{mkDateYD(2022, 3), decimal.NewFromFloat(0.0)}, // Filled (markets closed)
+		{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
+		{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(0.0)}, // Filled (markets closed)
+		{Date: mkDateYD(2022, 3), ForeignToLocalRate: decimal.NewFromFloat(0.0)}, // Filled (markets closed)
 	}
 
 	// Test lookup of well-known cached value for tomorrow, today, yesterday
@@ -231,7 +231,7 @@ func TestGetEffectiveUsdCadRateWithCache(t *testing.T) {
 		date.TodaysDateForTest = mkDateYD(2022, i)
 		rate, err := rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 1))
 		rq.Nil(err)
-		crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)})
+		crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)})
 	}
 	// Test lookup of defined markets closed cached value for tomorrow, today, yesterday,
 	// where later values are present.
@@ -239,7 +239,7 @@ func TestGetEffectiveUsdCadRateWithCache(t *testing.T) {
 		date.TodaysDateForTest = mkDateYD(2022, i)
 		rate, err := rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 2))
 		rq.Nil(err)
-		crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)})
+		crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)})
 	}
 	// Test lookup of defined markets closed cached value for tomorrow, today, yesterday,
 	// where this is the last cached value.
@@ -247,7 +247,7 @@ func TestGetEffectiveUsdCadRateWithCache(t *testing.T) {
 		date.TodaysDateForTest = mkDateYD(2022, i)
 		rate, err := rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 3))
 		rq.Nil(err)
-		crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)})
+		crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)})
 	}
 }
 
@@ -259,17 +259,17 @@ func TestGetEffectiveUsdCadRateCacheInvalidation(t *testing.T) {
 	// no remote value
 	rateLoader, ratesCache, remote := NewTestRateLoader(false)
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+		{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
 	}
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 1), decimal.NewFromFloat(1.4)}, // Value change.
+		{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.4)}, // Value change.
 	}
 	date.TodaysDateForTest = mkDateYD(2022, 2)
 	_, err := rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 2))
 	crq.Equal(ratesCache.RatesByYear[2022],
 		[]fx.DailyRate{
-			{mkDateYD(2022, 0), decimal.NewFromFloat(0.0)}, // fill
-			{mkDateYD(2022, 1), decimal.NewFromFloat(1.4)},
+			{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(0.0)}, // fill
+			{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.4)},
 		})
 	rq.NotNil(err) // Can't use today unless it's been published or specified.
 
@@ -277,53 +277,53 @@ func TestGetEffectiveUsdCadRateCacheInvalidation(t *testing.T) {
 	// a remote value
 	rateLoader, ratesCache, remote = NewTestRateLoader(false)
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
 	}
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+		{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
+		{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
 	}
 	date.TodaysDateForTest = mkDateYD(2022, 1)
 	rate, err := rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 1))
 	rq.Nil(err)
 	crq.Equal(ratesCache.RatesByYear[2022], remote.RemoteYearRates[2022])
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)})
 
 	// Test cache invalidates when querying a previous day with no cached value.
 	rateLoader, ratesCache, remote = NewTestRateLoader(false)
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
 	}
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-		{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
+		{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
+		{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
 	}
 	date.TodaysDateForTest = mkDateYD(2022, 4)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 1))
 	rq.Nil(err)
 	crq.Equal(ratesCache.RatesByYear[2022],
 		[]fx.DailyRate{
-			{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			{mkDateYD(2022, 2), decimal.NewFromFloat(0.0)}, // fill to yesterday
-			{mkDateYD(2022, 3), decimal.NewFromFloat(0.0)}, // fill to yesterday
+			{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
+			{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
+			{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(0.0)}, // fill to yesterday
+			{Date: mkDateYD(2022, 3), ForeignToLocalRate: decimal.NewFromFloat(0.0)}, // fill to yesterday
 		})
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)})
 
 	// Test cache does not invalidate when querying today with no cached value,
 	// after we already invalidated and refreshed the cache with this Loader instance.
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 0), decimal.NewFromFloat(99.0)},
-		{mkDateYD(2022, 1), decimal.NewFromFloat(99.1)},
+		{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(99.0)},
+		{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(99.1)},
 	}
 	_, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 4))
 	// Cache should be unchanged
 	crq.Equal(ratesCache.RatesByYear[2022],
 		[]fx.DailyRate{
-			{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
-			{mkDateYD(2022, 1), decimal.NewFromFloat(1.1)},
-			{mkDateYD(2022, 2), decimal.NewFromFloat(0.0)},
-			{mkDateYD(2022, 3), decimal.NewFromFloat(0.0)},
+			{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
+			{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.1)},
+			{Date: mkDateYD(2022, 2), ForeignToLocalRate: decimal.NewFromFloat(0.0)},
+			{Date: mkDateYD(2022, 3), ForeignToLocalRate: decimal.NewFromFloat(0.0)},
 		})
 	rq.NotNil(err) // Can't use today unless it's been published or specified.
 
@@ -331,16 +331,16 @@ func TestGetEffectiveUsdCadRateCacheInvalidation(t *testing.T) {
 	rateLoader, ratesCache, remote = NewTestRateLoader(false)
 	rateLoader.ForceDownload = true
 	ratesCache.RatesByYear[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 0), decimal.NewFromFloat(1.0)},
+		{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(1.0)},
 	}
 	remote.RemoteYearRates[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 0), decimal.NewFromFloat(99.0)},
+		{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(99.0)},
 	}
 	date.TodaysDateForTest = mkDateYD(2022, 1)
 	rate, err = rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 0))
 	rq.Nil(err)
 	crq.Equal(ratesCache.RatesByYear[2022], remote.RemoteYearRates[2022])
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 0), decimal.NewFromFloat(99.0)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 0), ForeignToLocalRate: decimal.NewFromFloat(99.0)})
 }
 
 func TestGetEffectiveUsdCadRateWithCsvCache(t *testing.T) {
@@ -364,14 +364,14 @@ func TestGetEffectiveUsdCadRateWithCsvCache(t *testing.T) {
 	}
 
 	remoteLoader.RemoteYearRates[2022] = []fx.DailyRate{
-		{mkDateYD(2022, 1), decimal.NewFromFloat(1.2)},
+		{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.2)},
 	}
 
 	// fetch mocked remote values and write to cache
 	rate, err := rateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 1))
 
 	rq.Nil(err)
-	crq.Equal(rate, fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.2)})
+	crq.Equal(rate, fx.DailyRate{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.2)})
 
 	// remove remote values to ensure cache is used
 	remoteLoader.RemoteYearRates[2022] = []fx.DailyRate{}
@@ -388,5 +388,5 @@ func TestGetEffectiveUsdCadRateWithCsvCache(t *testing.T) {
 	cachedRate, err := cachedRateLoader.GetEffectiveUsdCadRate(mkDateYD(2022, 1))
 
 	rq.Nil(err)
-	crq.Equal(cachedRate, fx.DailyRate{mkDateYD(2022, 1), decimal.NewFromFloat(1.2)})
+	crq.Equal(cachedRate, fx.DailyRate{Date: mkDateYD(2022, 1), ForeignToLocalRate: decimal.NewFromFloat(1.2)})
 }

--- a/test/portfolio_test_lib.go
+++ b/test/portfolio_test_lib.go
@@ -38,7 +38,7 @@ func mkDate(day int) date.Date {
 
 func CADSFL(lossVal decimal.Decimal, force bool) ptf.SFLInputOpt {
 	util.Assert(lossVal.LessThanOrEqual(decimal.Zero))
-	return ptf.NewSFLInputOpt(ptf.SFLInput{decimal_opt.New(lossVal), force})
+	return ptf.NewSFLInputOpt(ptf.SFLInput{SuperficialLoss: decimal_opt.New(lossVal), Force: force})
 }
 
 func addTx(tx *ptf.Tx, preTxStatus *ptf.PortfolioSecurityStatus) (*ptf.TxDelta, []*ptf.Tx, error) {

--- a/test/portfolio_test_lib.go
+++ b/test/portfolio_test_lib.go
@@ -233,7 +233,7 @@ func TxTestEqual(exp, actual *ptf.Tx) bool {
 
 func ValidateTxs(t *testing.T, expTxs []*ptf.Tx, actualTxs []*ptf.Tx) {
 	if !assert.Equal(t, len(expTxs), len(actualTxs)) {
-		for j, _ := range actualTxs {
+		for j := range actualTxs {
 			fmt.Println(j, "Tx:", actualTxs[j], "Af:", actualTxs[j].Affiliate.Id())
 		}
 		require.FailNow(t, "ValidateTxs failed")
@@ -243,7 +243,7 @@ func ValidateTxs(t *testing.T, expTxs []*ptf.Tx, actualTxs []*ptf.Tx) {
 		diff := TxDiff(expTxs[i], tx)
 		fail = diff != ""
 		if fail {
-			for j, _ := range actualTxs {
+			for j := range actualTxs {
 				fmt.Println(j, "Tx:", actualTxs[j], "Af:", actualTxs[j].Affiliate.Id())
 			}
 			require.FailNowf(t, "ValidateTxs failed", "Tx %d, diff: %s", i, diff)
@@ -265,7 +265,7 @@ func ValidateDelta(t *testing.T, delta *ptf.TxDelta, expDelta TDt) {
 
 func ValidateDeltas(t *testing.T, deltas []*ptf.TxDelta, expDeltas []TDt) {
 	if len(expDeltas) != len(deltas) {
-		for j, _ := range deltas {
+		for j := range deltas {
 			fmt.Println(j, "Tx:", deltas[j].Tx, "\n   PostStatus:", deltas[j].PostStatus)
 		}
 		require.Equal(t, len(expDeltas), len(deltas), "Num deltas did not match")
@@ -277,7 +277,7 @@ func ValidateDeltas(t *testing.T, deltas []*ptf.TxDelta, expDeltas []TDt) {
 		fail = !expDeltas[i].Gain.Equal(delta.CapitalGain) || fail
 		fail = (expDeltas[i].PotentiallyOverAppliedSfl != delta.PotentiallyOverAppliedSfl) || fail
 		if fail {
-			for j, _ := range deltas {
+			for j := range deltas {
 				fmt.Println(j, "Tx:", deltas[j].Tx, "\n   PostStatus:", deltas[j].PostStatus,
 					"\n   Gain:", deltas[j].CapitalGain, "\n   SFL:", deltas[j].SuperficialLoss,
 					"\n   PotentiallyOverAppliedSfl:", deltas[j].PotentiallyOverAppliedSfl)

--- a/test/sample_files_test.go
+++ b/test/sample_files_test.go
@@ -17,7 +17,7 @@ func validateSampleCsvFile(rq *require.Assertions, csvPath string, cachePath str
 	fp, err := os.Open(csvPath)
 	rq.Nil(err)
 	defer fp.Close()
-	csvReaders := []app.DescribedReader{{csvPath, fp}}
+	csvReaders := []app.DescribedReader{{Desc: csvPath, Reader: fp}}
 
 	errPrinter := &log.StderrErrorPrinter{}
 	_, err = app.RunAcbAppToRenderModel(

--- a/test/sample_files_test.go
+++ b/test/sample_files_test.go
@@ -17,7 +17,7 @@ func validateSampleCsvFile(rq *require.Assertions, csvPath string, cachePath str
 	fp, err := os.Open(csvPath)
 	rq.Nil(err)
 	defer fp.Close()
-	csvReaders := []app.DescribedReader{app.DescribedReader{csvPath, fp}}
+	csvReaders := []app.DescribedReader{{csvPath, fp}}
 
 	errPrinter := &log.StderrErrorPrinter{}
 	_, err = app.RunAcbAppToRenderModel(

--- a/test/txdelta_test.go
+++ b/test/txdelta_test.go
@@ -118,8 +118,8 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero},
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(6.0)}, Gain: DOFlt(-5.0)},
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(6.0)}, Gain: DOFlt(-5.0)},
 	})
 
 	// (min(#sold, totalAquired, endBalance) / #sold) x (Total Loss)
@@ -141,12 +141,12 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero},
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(6.0)}, Gain: DOFlt(-4.0)},      // $1 superficial
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.0)}, Gain: decimal_opt.Zero}, // acb adjust
-		TDt{PostSt: TPSS{Shares: DInt(1), TotalAcb: DOFlt(1.4)}, Gain: DOFlt(-3.6)},      // $1.2 superficial
-		TDt{PostSt: TPSS{Shares: DInt(1), TotalAcb: DOFlt(2.6)}, Gain: decimal_opt.Zero}, // acb adjust
-		TDt{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: decimal_opt.Zero}, Gain: DOFlt(-2.4)},
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(6.0)}, Gain: DOFlt(-4.0)},      // $1 superficial
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.0)}, Gain: decimal_opt.Zero}, // acb adjust
+		{PostSt: TPSS{Shares: DInt(1), TotalAcb: DOFlt(1.4)}, Gain: DOFlt(-3.6)},      // $1.2 superficial
+		{PostSt: TPSS{Shares: DInt(1), TotalAcb: DOFlt(2.6)}, Gain: decimal_opt.Zero}, // acb adjust
+		{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: decimal_opt.Zero}, Gain: DOFlt(-2.4)},
 	})
 
 	/*
@@ -163,10 +163,10 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero}, // buy
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(6.0)}, Gain: decimal_opt.Zero},   // sell sfl $1
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(11.0)}, Gain: decimal_opt.Zero},  // sfl ACB adjust
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(14.0)}, Gain: decimal_opt.Zero}, // buy
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero}, // buy
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(6.0)}, Gain: decimal_opt.Zero},   // sell sfl $1
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(11.0)}, Gain: decimal_opt.Zero},  // sfl ACB adjust
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(14.0)}, Gain: decimal_opt.Zero}, // buy
 	})
 
 	/*
@@ -184,10 +184,10 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(14.4)}, Gain: decimal_opt.Zero}, // buy, ACB (CAD) = (10*1.0 + 2) * 1.2
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.2)}, Gain: decimal_opt.Zero},   // sell sfl $1 USD (1.2 CAD)
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(13.2)}, Gain: decimal_opt.Zero},  // sfl ACB adjust
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(16.8)}, Gain: decimal_opt.Zero}, // buy
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(14.4)}, Gain: decimal_opt.Zero}, // buy, ACB (CAD) = (10*1.0 + 2) * 1.2
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.2)}, Gain: decimal_opt.Zero},   // sell sfl $1 USD (1.2 CAD)
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(13.2)}, Gain: decimal_opt.Zero},  // sfl ACB adjust
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(16.8)}, Gain: decimal_opt.Zero}, // buy
 	})
 
 	/*
@@ -204,9 +204,9 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero},
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(6.0)}, Gain: DOFlt(-5.0)},
-		TDt{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: decimal_opt.Zero}, Gain: DOFlt(-5.0)},
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(6.0)}, Gain: DOFlt(-5.0)},
+		{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: decimal_opt.Zero}, Gain: DOFlt(-5.0)},
 	})
 
 	/*
@@ -222,10 +222,10 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DFlt(100), TotalAcb: DOFlt(302.0)}, Gain: decimal_opt.Zero},
-		TDt{PostSt: TPSS{Shares: DInt(1), TotalAcb: DOFlt(3.02)}, Gain: DOStr("-75.48000000000000255")},     // total loss of 100.98, 25.500000048 is superficial
-		TDt{PostSt: TPSS{Shares: DInt(1), TotalAcb: DOStr("28.51999999999999745")}, Gain: decimal_opt.Zero}, // acb adjust
-		TDt{PostSt: TPSS{Shares: DFlt(26), TotalAcb: DOStr("85.51999999999999745")}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: DFlt(100), TotalAcb: DOFlt(302.0)}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: DInt(1), TotalAcb: DOFlt(3.02)}, Gain: DOStr("-75.48000000000000255")},     // total loss of 100.98, 25.500000048 is superficial
+		{PostSt: TPSS{Shares: DInt(1), TotalAcb: DOStr("28.51999999999999745")}, Gain: decimal_opt.Zero}, // acb adjust
+		{PostSt: TPSS{Shares: DFlt(26), TotalAcb: DOStr("85.51999999999999745")}, Gain: decimal_opt.Zero},
 	})
 
 	/*
@@ -246,13 +246,13 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero},
-		TDt{PostSt: TPSS{Shares: DFlt(0), TotalAcb: DOFlt(0)}, Gain: DOFlt(-7)},        // Superficial loss of 3
-		TDt{PostSt: TPSS{Shares: DFlt(0), TotalAcb: DOFlt(3)}, Gain: decimal_opt.Zero}, // acb adjust
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(10.0)}, Gain: decimal_opt.Zero},
-		TDt{PostSt: TPSS{Shares: DInt(3), TotalAcb: DOFlt(6.0)}, Gain: decimal_opt.Zero}, // Superficial loss of 3.6
-		TDt{PostSt: TPSS{Shares: DInt(3), TotalAcb: DOFlt(9.6)}, Gain: decimal_opt.Zero}, // acb adjust
-		TDt{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: decimal_opt.Zero}, Gain: DOFlt(-9)},
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: DFlt(0), TotalAcb: DOFlt(0)}, Gain: DOFlt(-7)},        // Superficial loss of 3
+		{PostSt: TPSS{Shares: DFlt(0), TotalAcb: DOFlt(3)}, Gain: decimal_opt.Zero}, // acb adjust
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(10.0)}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: DInt(3), TotalAcb: DOFlt(6.0)}, Gain: decimal_opt.Zero}, // Superficial loss of 3.6
+		{PostSt: TPSS{Shares: DInt(3), TotalAcb: DOFlt(9.6)}, Gain: decimal_opt.Zero}, // acb adjust
+		{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: decimal_opt.Zero}, Gain: DOFlt(-9)},
 	})
 
 	/*
@@ -266,8 +266,8 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero},
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(6.0)}, Gain: DOFlt(4.0)},
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(12.0)}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(6.0)}, Gain: DOFlt(4.0)},
 	})
 
 	/* Fractional shares SFL avoidance
@@ -286,9 +286,9 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.0)}, Gain: decimal_opt.Zero},
-		TDt{PostSt: TPSS{Shares: DStr("0.3"), TotalAcb: DOFlt(0.42)}, Gain: DOFlt(-5.64)},
-		TDt{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: decimal_opt.Zero}, Gain: DOFlt(-0.36)},
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.0)}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: DStr("0.3"), TotalAcb: DOFlt(0.42)}, Gain: DOFlt(-5.64)},
+		{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: decimal_opt.Zero}, Gain: DOFlt(-0.36)},
 	})
 
 	// ************** Explicit Superficial Losses ***************************
@@ -310,10 +310,10 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(14.4)}, Gain: decimal_opt.Zero}, // buy, ACB (CAD) = (10*1.0 + 2) * 1.2
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.2)}, Gain: decimal_opt.Zero},   // sell for $1 USD, capital loss $-5 USD before SFL deduction, sfl 0.7 CAD
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.3)}, Gain: decimal_opt.Zero},   // sfl ACB adjust 0.02 * 5
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(10.9)}, Gain: decimal_opt.Zero}, // buy
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(14.4)}, Gain: decimal_opt.Zero}, // buy, ACB (CAD) = (10*1.0 + 2) * 1.2
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.2)}, Gain: decimal_opt.Zero},   // sell for $1 USD, capital loss $-5 USD before SFL deduction, sfl 0.7 CAD
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.3)}, Gain: decimal_opt.Zero},   // sfl ACB adjust 0.02 * 5
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(10.9)}, Gain: decimal_opt.Zero}, // buy
 	})
 
 	// Override a detected SFL
@@ -334,10 +334,10 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(14.4)}, Gain: decimal_opt.Zero}, // buy, ACB (CAD) = (10*1.0 + 2) * 1.2
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.2)}, Gain: DOFlt(-5.3)},        // sell for $1 USD, capital loss $-5 USD before SFL deduction, sfl 0.7 CAD
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.3)}, Gain: decimal_opt.Zero},   // sfl ACB adjust 0.02 * 5
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(10.9)}, Gain: decimal_opt.Zero}, // buy
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(14.4)}, Gain: decimal_opt.Zero}, // buy, ACB (CAD) = (10*1.0 + 2) * 1.2
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.2)}, Gain: DOFlt(-5.3)},        // sell for $1 USD, capital loss $-5 USD before SFL deduction, sfl 0.7 CAD
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.3)}, Gain: decimal_opt.Zero},   // sfl ACB adjust 0.02 * 5
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(10.9)}, Gain: decimal_opt.Zero}, // buy
 	})
 
 	// Un-force the override, and check that we emit an error
@@ -361,9 +361,9 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(14.4)}, Gain: decimal_opt.Zero}, // buy, ACB (CAD) = (10*1.0 + 2) * 1.2
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.2)}, Gain: DOFlt(-5.3)},        // sell for $1 USD, capital loss $-5 USD before SFL deduction, sfl 0.7 CAD
-		TDt{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.3)}, Gain: decimal_opt.Zero},   // sfl ACB adjust 0.02 * 5
+		{PostSt: TPSS{Shares: DInt(10), TotalAcb: DOFlt(14.4)}, Gain: decimal_opt.Zero}, // buy, ACB (CAD) = (10*1.0 + 2) * 1.2
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.2)}, Gain: DOFlt(-5.3)},        // sell for $1 USD, capital loss $-5 USD before SFL deduction, sfl 0.7 CAD
+		{PostSt: TPSS{Shares: DInt(5), TotalAcb: DOFlt(7.3)}, Gain: decimal_opt.Zero},   // sfl ACB adjust 0.02 * 5
 	})
 
 	// Un-force the override, and check that we emit an error
@@ -378,7 +378,7 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: DOFlt(0.1)}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: DOFlt(0.1)}, Gain: decimal_opt.Zero},
 	})
 
 	txs = []*ptf.Tx{
@@ -386,7 +386,7 @@ func TestSuperficialLosses(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: DOFlt(0.1)}, Gain: decimal_opt.Zero},
+		{PostSt: TPSS{Shares: decimal.Zero, TotalAcb: DOFlt(0.1)}, Gain: decimal_opt.Zero},
 	})
 	// Non 1.0 exchange rate
 	txs = []*ptf.Tx{
@@ -527,15 +527,15 @@ func TestMultiAffiliateGains(t *testing.T) {
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
 		// Buys
-		TDt{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), AcbPerSh: DOFlt(1.0)}},
-		TDt{PostSt: TPSS{Shares: DInt(20), AllShares: DInt(30), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null},
-		TDt{PostSt: TPSS{Shares: DInt(30), AllShares: DInt(60), AcbPerSh: DOFlt(1.0)}},
-		TDt{PostSt: TPSS{Shares: DInt(40), AllShares: DInt(100), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null},
+		{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), AcbPerSh: DOFlt(1.0)}},
+		{PostSt: TPSS{Shares: DInt(20), AllShares: DInt(30), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null},
+		{PostSt: TPSS{Shares: DInt(30), AllShares: DInt(60), AcbPerSh: DOFlt(1.0)}},
+		{PostSt: TPSS{Shares: DInt(40), AllShares: DInt(100), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null},
 		// Sells
-		TDt{PostSt: TPSS{Shares: DInt(9), AllShares: DInt(99), AcbPerSh: DOFlt(1.0)}, Gain: DOFlt(1 * 0.2)},
-		TDt{PostSt: TPSS{Shares: DInt(18), AllShares: DInt(97), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null},
-		TDt{PostSt: TPSS{Shares: DInt(27), AllShares: DInt(94), AcbPerSh: DOFlt(1.0)}, Gain: DOFlt(3 * 0.4)},
-		TDt{PostSt: TPSS{Shares: DInt(36), AllShares: DInt(90), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null},
+		{PostSt: TPSS{Shares: DInt(9), AllShares: DInt(99), AcbPerSh: DOFlt(1.0)}, Gain: DOFlt(1 * 0.2)},
+		{PostSt: TPSS{Shares: DInt(18), AllShares: DInt(97), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null},
+		{PostSt: TPSS{Shares: DInt(27), AllShares: DInt(94), AcbPerSh: DOFlt(1.0)}, Gain: DOFlt(3 * 0.4)},
+		{PostSt: TPSS{Shares: DInt(36), AllShares: DInt(90), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null},
 	})
 }
 
@@ -560,13 +560,13 @@ func TestMultiAffiliateRoC(t *testing.T) {
 	deltas := TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
 		// Buys
-		TDt{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), AcbPerSh: DOFlt(1.0)}}, // Default
-		TDt{PostSt: TPSS{Shares: DInt(20), AllShares: DInt(30), AcbPerSh: DOFlt(1.0)}}, // B
+		{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), AcbPerSh: DOFlt(1.0)}}, // Default
+		{PostSt: TPSS{Shares: DInt(20), AllShares: DInt(30), AcbPerSh: DOFlt(1.0)}}, // B
 		// ROC
-		TDt{PostSt: TPSS{Shares: DInt(20), AllShares: DInt(30), AcbPerSh: DOFlt(0.8)}}, // B
+		{PostSt: TPSS{Shares: DInt(20), AllShares: DInt(30), AcbPerSh: DOFlt(0.8)}}, // B
 		// Sells
-		TDt{PostSt: TPSS{Shares: decimal.Zero, AllShares: DInt(20), AcbPerSh: decimal_opt.Zero}, Gain: DOFlt(10 * 0.1)},     // Default
-		TDt{PostSt: TPSS{Shares: decimal.Zero, AllShares: decimal.Zero, AcbPerSh: decimal_opt.Zero}, Gain: DOFlt(20 * 0.3)}, // B
+		{PostSt: TPSS{Shares: decimal.Zero, AllShares: DInt(20), AcbPerSh: decimal_opt.Zero}, Gain: DOFlt(10 * 0.1)},     // Default
+		{PostSt: TPSS{Shares: decimal.Zero, AllShares: decimal.Zero, AcbPerSh: decimal_opt.Zero}, Gain: DOFlt(20 * 0.3)}, // B
 	})
 }
 
@@ -588,11 +588,11 @@ func TestOtherAffiliateSFL(t *testing.T) {
 	}
 	deltas := TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                 // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), TotalAcb: DOFlt(5.0)}},                   // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(13), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)}, // SFL of 0.5 * 2 shares
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(13), TotalAcb: DOFlt(6.0)}},                   // Auto-adjust on B
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(15), TotalAcb: DOFlt(8.0)}},                   // B
+		{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                 // Buy in Default
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), TotalAcb: DOFlt(5.0)}},                   // Buy in B
+		{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(13), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)}, // SFL of 0.5 * 2 shares
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(13), TotalAcb: DOFlt(6.0)}},                   // Auto-adjust on B
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(15), TotalAcb: DOFlt(8.0)}},                   // B
 	})
 
 	/* SFL with all buys on registered affiliate
@@ -606,10 +606,10 @@ func TestOtherAffiliateSFL(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                             // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
-		TDt{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(13), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)},             // SFL of 0.5 * 2 shares
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(15), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
+		{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                             // Buy in Default
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
+		{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(13), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)},             // SFL of 0.5 * 2 shares
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(15), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
 	})
 
 	/* SFL with all buys on other affiliate B, but sells on a second affiliate (R)
@@ -625,13 +625,13 @@ func TestOtherAffiliateSFL(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                             // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), TotalAcb: DOFlt(5.0)}},                               // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(20), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
-		TDt{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(18), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)},             // SFL of 0.5 * 2 shares
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(18), TotalAcb: DOFlt(6.0)}},                               // Auto-adjust on B
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(20), TotalAcb: DOFlt(8.0)}},                               // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(3), AllShares: DInt(18), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Sell in (R)
+		{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                             // Buy in Default
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), TotalAcb: DOFlt(5.0)}},                               // Buy in B
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(20), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
+		{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(18), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)},             // SFL of 0.5 * 2 shares
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(18), TotalAcb: DOFlt(6.0)}},                               // Auto-adjust on B
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(20), TotalAcb: DOFlt(8.0)}},                               // Buy in B
+		{PostSt: TPSS{Shares: DInt(3), AllShares: DInt(18), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Sell in (R)
 	})
 
 	/* SFL with buys on two other affiliates (both non-registered)
@@ -652,14 +652,14 @@ func TestOtherAffiliateSFL(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                 // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), TotalAcb: DOFlt(5.0)}},                   // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: DOFlt(7.0)}},                   // Buy in C
-		TDt{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(20), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)}, // SFL of 0.5 * 2 shares
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(20), TotalAcb: DOFlt(5.4375)}},                // Auto-adjust on B. Gets 7/16 (43.75%) of the SFL
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(20), TotalAcb: DOFlt(7.5625)}},                // Auto-adjust on C. Gets 9/16 (56.25%) of the SFL
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: DOFlt(7.4375)}},                // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(9), AllShares: DInt(24), TotalAcb: DOFlt(9.5625)}},                // Buy in C
+		{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                 // Buy in Default
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), TotalAcb: DOFlt(5.0)}},                   // Buy in B
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: DOFlt(7.0)}},                   // Buy in C
+		{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(20), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)}, // SFL of 0.5 * 2 shares
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(20), TotalAcb: DOFlt(5.4375)}},                // Auto-adjust on B. Gets 7/16 (43.75%) of the SFL
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(20), TotalAcb: DOFlt(7.5625)}},                // Auto-adjust on C. Gets 9/16 (56.25%) of the SFL
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: DOFlt(7.4375)}},                // Buy in B
+		{PostSt: TPSS{Shares: DInt(9), AllShares: DInt(24), TotalAcb: DOFlt(9.5625)}},                // Buy in C
 	})
 
 	/* SFL with buys on two other affiliates (registered/non-registered)
@@ -680,13 +680,13 @@ func TestOtherAffiliateSFL(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                             // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), AcbPerSh: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: DOFlt(7.0)}},                               // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(20), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)},             // SFL of 0.5 * 2 shares
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(20), TotalAcb: DOFlt(7.5625)}},                            // Auto-adjust on B. Gets 9/16 (56.25%) of the SFL
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
-		TDt{PostSt: TPSS{Shares: DInt(9), AllShares: DInt(24), TotalAcb: DOFlt(9.5625)}},                            // Buy in B
+		{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                             // Buy in Default
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), AcbPerSh: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: DOFlt(7.0)}},                               // Buy in B
+		{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(20), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)},             // SFL of 0.5 * 2 shares
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(20), TotalAcb: DOFlt(7.5625)}},                            // Auto-adjust on B. Gets 9/16 (56.25%) of the SFL
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
+		{PostSt: TPSS{Shares: DInt(9), AllShares: DInt(24), TotalAcb: DOFlt(9.5625)}},                            // Buy in B
 	})
 
 	/* SFL with buys on one other affiliate, but fewer shares in the only selling
@@ -708,12 +708,12 @@ func TestOtherAffiliateSFL(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(5), TotalAcb: DOFlt(5.0)}}, // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(1), TotalAcb: DOFlt(1.0)}, Gain: DOFlt(-1.0), SFL: DOFlt(-1.0),
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(5), TotalAcb: DOFlt(5.0)}}, // Buy in Default
+		{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(1), TotalAcb: DOFlt(1.0)}, Gain: DOFlt(-1.0), SFL: DOFlt(-1.0),
 			PotentiallyOverAppliedSfl: true}, // SFL of 0.5 * 2(/4) shares
-		TDt{PostSt: TPSS{Shares: decimal.Zero, AllShares: DInt(1), TotalAcb: DOFlt(1.0)}},               // auto adjust on B (100%)
-		TDt{PostSt: TPSS{Shares: DInt(2), AllShares: DInt(3), TotalAcb: DOFlt(3.0)}},                    // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(2), TotalAcb: DOFlt(1.5)}, Gain: DOFlt(0.50)}, // Sell in B
+		{PostSt: TPSS{Shares: decimal.Zero, AllShares: DInt(1), TotalAcb: DOFlt(1.0)}},               // auto adjust on B (100%)
+		{PostSt: TPSS{Shares: DInt(2), AllShares: DInt(3), TotalAcb: DOFlt(3.0)}},                    // Buy in B
+		{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(2), TotalAcb: DOFlt(1.5)}, Gain: DOFlt(0.50)}, // Sell in B
 	})
 
 	/* SFL with buys on both SFL affiliate and one other affiliate.
@@ -734,12 +734,12 @@ func TestOtherAffiliateSFL(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(5), TotalAcb: DOFlt(5.0)}},                                      // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(1), TotalAcb: DOFlt(1.0)}, Gain: DOFlt(-0.5), SFL: DOFlt(-1.5)}, // SFL of 0.5 * 3(/4) shares
-		TDt{PostSt: TPSS{Shares: decimal.Zero, AllShares: DInt(1), TotalAcb: DOFlt(0.75)}},                                // auto adjust on B (50%)
-		TDt{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(1), TotalAcb: DOFlt(1.75)}},                                     // auto adjust on default (50%)
-		TDt{PostSt: TPSS{Shares: DInt(2), AllShares: DInt(3), TotalAcb: DOFlt(2.75)}},                                     // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(2), AllShares: DInt(4), TotalAcb: DOFlt(3.75)}},                                     // Buy in default
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(5), TotalAcb: DOFlt(5.0)}},                                      // Buy in Default
+		{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(1), TotalAcb: DOFlt(1.0)}, Gain: DOFlt(-0.5), SFL: DOFlt(-1.5)}, // SFL of 0.5 * 3(/4) shares
+		{PostSt: TPSS{Shares: decimal.Zero, AllShares: DInt(1), TotalAcb: DOFlt(0.75)}},                                // auto adjust on B (50%)
+		{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(1), TotalAcb: DOFlt(1.75)}},                                     // auto adjust on default (50%)
+		{PostSt: TPSS{Shares: DInt(2), AllShares: DInt(3), TotalAcb: DOFlt(2.75)}},                                     // Buy in B
+		{PostSt: TPSS{Shares: DInt(2), AllShares: DInt(4), TotalAcb: DOFlt(3.75)}},                                     // Buy in default
 	})
 
 	/* SFL with buy on one other registered affiliate.
@@ -758,9 +758,9 @@ func TestOtherAffiliateSFL(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(5), TotalAcb: DOFlt(5.0)}},                                      // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(1), TotalAcb: DOFlt(1.0)}, Gain: DOFlt(-1.0), SFL: DOFlt(-1.0)}, // SFL of 0.5 * 2(/4) shares
-		TDt{PostSt: TPSS{Shares: DInt(2), AllShares: DInt(3), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null},        // Buy in B
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(5), TotalAcb: DOFlt(5.0)}},                                      // Buy in Default
+		{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(1), TotalAcb: DOFlt(1.0)}, Gain: DOFlt(-1.0), SFL: DOFlt(-1.0)}, // SFL of 0.5 * 2(/4) shares
+		{PostSt: TPSS{Shares: DInt(2), AllShares: DInt(3), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null},        // Buy in B
 	})
 
 	/* SFL with buy on one other registered affiliate, but fewer shares in the only
@@ -782,11 +782,11 @@ func TestOtherAffiliateSFL(t *testing.T) {
 	}
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(5), TotalAcb: DOFlt(5.0)}}, // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(1), TotalAcb: DOFlt(1.0)}, Gain: DOFlt(-1.0), SFL: DOFlt(-1.0),
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(5), TotalAcb: DOFlt(5.0)}}, // Buy in Default
+		{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(1), TotalAcb: DOFlt(1.0)}, Gain: DOFlt(-1.0), SFL: DOFlt(-1.0),
 			PotentiallyOverAppliedSfl: true}, // SFL of 0.5 * 2(/4) shares
-		TDt{PostSt: TPSS{Shares: DInt(2), AllShares: DInt(3), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
-		TDt{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(2), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Sell in (R)
+		{PostSt: TPSS{Shares: DInt(2), AllShares: DInt(3), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
+		{PostSt: TPSS{Shares: DInt(1), AllShares: DInt(2), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Sell in (R)
 	})
 }
 
@@ -814,13 +814,13 @@ func TestOtherAffiliateExplicitSFL(t *testing.T) {
 	}
 	deltas := TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                 // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), AcbPerSh: DOFlt(1.0)}},                   // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: DOFlt(7.0)}},                   // Buy in C
-		TDt{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(20), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)}, // SFL of 0.5 * 2 shares
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(20), TotalAcb: DOFlt(7.5)}},                   // Explicit adjust on C
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), AcbPerSh: DOFlt(1.0)}},                   // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(9), AllShares: DInt(24), TotalAcb: DOFlt(9.5)}},                   // Buy in C
+		{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                 // Buy in Default
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), AcbPerSh: DOFlt(1.0)}},                   // Buy in B
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: DOFlt(7.0)}},                   // Buy in C
+		{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(20), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)}, // SFL of 0.5 * 2 shares
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(20), TotalAcb: DOFlt(7.5)}},                   // Explicit adjust on C
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), AcbPerSh: DOFlt(1.0)}},                   // Buy in B
+		{PostSt: TPSS{Shares: DInt(9), AllShares: DInt(24), TotalAcb: DOFlt(9.5)}},                   // Buy in C
 	})
 
 	/* SFL with sells on two other affiliates (registered/non-registered),
@@ -845,29 +845,29 @@ func TestOtherAffiliateExplicitSFL(t *testing.T) {
 
 	deltas = TxsToDeltaListNoErr(t, txs)
 	ValidateDeltas(t, deltas, []TDt{
-		TDt{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                             // Buy in Default
-		TDt{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), AcbPerSh: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: DOFlt(7.0)}},                               // Buy in B
-		TDt{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(20), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)},             // SFL of 0.5 * 2 shares
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(20), TotalAcb: DOFlt(7.5)}},                               // Explicit adjust on B
-		TDt{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
-		TDt{PostSt: TPSS{Shares: DInt(9), AllShares: DInt(24), TotalAcb: DOFlt(9.5)}},                               // Buy in B
+		{PostSt: TPSS{Shares: DInt(10), AllShares: DInt(10), TotalAcb: DOFlt(10.0)}},                             // Buy in Default
+		{PostSt: TPSS{Shares: DInt(5), AllShares: DInt(15), AcbPerSh: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: DOFlt(7.0)}},                               // Buy in B
+		{PostSt: TPSS{Shares: DInt(8), AllShares: DInt(20), TotalAcb: DOFlt(8.0)}, SFL: DOFlt(-1.0)},             // SFL of 0.5 * 2 shares
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(20), TotalAcb: DOFlt(7.5)}},                               // Explicit adjust on B
+		{PostSt: TPSS{Shares: DInt(7), AllShares: DInt(22), TotalAcb: decimal_opt.Null}, Gain: decimal_opt.Null}, // Buy in (R)
+		{PostSt: TPSS{Shares: DInt(9), AllShares: DInt(24), TotalAcb: DOFlt(9.5)}},                               // Buy in B
 	})
 }
 
 func TestTxSort(t *testing.T) {
 	txs := []*ptf.Tx{
-		&ptf.Tx{Security: "FOO2", SettlementDate: mkDate(2), Action: ptf.SELL, ReadIndex: 0},
-		&ptf.Tx{Security: "FOO2", SettlementDate: mkDate(2), Action: ptf.BUY, ReadIndex: 3},
-		&ptf.Tx{Security: "FOO3", SettlementDate: mkDate(3), Action: ptf.BUY, ReadIndex: 1},
-		&ptf.Tx{Security: "FOO1", SettlementDate: mkDate(1), Action: ptf.BUY, ReadIndex: 2},
+		{Security: "FOO2", SettlementDate: mkDate(2), Action: ptf.SELL, ReadIndex: 0},
+		{Security: "FOO2", SettlementDate: mkDate(2), Action: ptf.BUY, ReadIndex: 3},
+		{Security: "FOO3", SettlementDate: mkDate(3), Action: ptf.BUY, ReadIndex: 1},
+		{Security: "FOO1", SettlementDate: mkDate(1), Action: ptf.BUY, ReadIndex: 2},
 	}
 
 	expTxs := []*ptf.Tx{
-		&ptf.Tx{Security: "FOO1", SettlementDate: mkDate(1), Action: ptf.BUY, ReadIndex: 2},
-		&ptf.Tx{Security: "FOO2", SettlementDate: mkDate(2), Action: ptf.SELL, ReadIndex: 0},
-		&ptf.Tx{Security: "FOO2", SettlementDate: mkDate(2), Action: ptf.BUY, ReadIndex: 3},
-		&ptf.Tx{Security: "FOO3", SettlementDate: mkDate(3), Action: ptf.BUY, ReadIndex: 1},
+		{Security: "FOO1", SettlementDate: mkDate(1), Action: ptf.BUY, ReadIndex: 2},
+		{Security: "FOO2", SettlementDate: mkDate(2), Action: ptf.SELL, ReadIndex: 0},
+		{Security: "FOO2", SettlementDate: mkDate(2), Action: ptf.BUY, ReadIndex: 3},
+		{Security: "FOO3", SettlementDate: mkDate(3), Action: ptf.BUY, ReadIndex: 1},
 	}
 
 	ptf.SortTxs(txs)

--- a/util/map.go
+++ b/util/map.go
@@ -13,11 +13,11 @@ func MapKeys[K comparable, V any](m map[K]V) []K {
 }
 
 func IntDecimalOptMapKeys(m map[int]decimal_opt.DecimalOpt) []int {
-	return MapKeys[int, decimal_opt.DecimalOpt](m)
+	return MapKeys(m)
 }
 
 func IntFloat64MapKeys(m map[int]float64) []int {
-	return MapKeys[int, float64](m)
+	return MapKeys(m)
 }
 
 type DefaultMap[K comparable, V any] struct {

--- a/util/set.go
+++ b/util/set.go
@@ -28,7 +28,7 @@ func (m *Set[T]) Len() int {
 }
 
 func (m *Set[T]) ForEach(fn func(T) bool) {
-	for k, _ := range m.set {
+	for k := range m.set {
 		if !fn(k) {
 			break
 		}
@@ -37,7 +37,7 @@ func (m *Set[T]) ForEach(fn func(T) bool) {
 
 func (m *Set[T]) ToSlice() []T {
 	slice := make([]T, 0, len(m.set))
-	for k, _ := range m.set {
+	for k := range m.set {
 		slice = append(slice, k)
 	}
 	return slice

--- a/www/wasm/main.go
+++ b/www/wasm/main.go
@@ -265,7 +265,7 @@ func makeRunAcbWrapper() js.Func {
 			return makeErrorPromise(err)
 		}
 		// We need a desc for each csv. Default them to empty string.
-		for i, _ := range contents {
+		for i := range contents {
 			var desc string = ""
 			if i < len(descs) {
 				desc = descs[i]


### PR DESCRIPTION
I ran `gofmt -w -s .` on the project, and then `gopls fix -w -a` on each `.go` file separately.

This creates a good baseline for subsequent changes.

It primarily fixes:
- struct literal uses unkeyed fields
- redundant type from array, slice, or map composite literal