### PR TITLE
app: refactor app output using new ACBWriter interface

### DIFF
--- a/app/outfmt/model.go
+++ b/app/outfmt/model.go
@@ -1,0 +1,16 @@
+package outfmt
+
+import (
+	"github.com/tsiemens/acb/portfolio"
+)
+
+type OutputType int
+
+const (
+	Transactions OutputType = iota
+	AggregateGains
+)
+
+type ACBWriter interface {
+	PrintRenderTable(outType OutputType, name string, tableModel *portfolio.RenderTable) error
+}

--- a/app/outfmt/std.go
+++ b/app/outfmt/std.go
@@ -1,0 +1,65 @@
+package outfmt
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/tsiemens/acb/portfolio"
+)
+
+type STDWriter struct {
+	w io.Writer
+}
+
+func NewSTDWriter(w io.Writer) *STDWriter {
+	return &STDWriter{
+		w: w,
+	}
+}
+
+// Write implements io.Writer.
+func (w *STDWriter) Write(p []byte) (int, error) {
+	n, err := w.w.Write(p)
+	if err != nil {
+		panic(fmt.Errorf("STDWriter.Write: %w", err))
+	}
+	return n, err
+}
+
+// PrintRenderTable implements ACBWriter.
+func (w *STDWriter) PrintRenderTable(outType OutputType, name string, tableModel *portfolio.RenderTable) error {
+	for _, err := range tableModel.Errors {
+		fmt.Fprintf(w, "[!] %v. Printing parsed information state:\n", err)
+	}
+	var title string
+	switch outType {
+	case Transactions:
+		title = fmt.Sprintf("Transactions for %s", name)
+	case AggregateGains:
+		title = "Aggregate Gains"
+	default:
+		panic(fmt.Sprint("OutputType ", outType, " is not implemented"))
+	}
+	fmt.Fprintf(w, "%s\n", title)
+
+	table := tablewriter.NewWriter(w)
+	table.SetHeader(tableModel.Header)
+	table.SetBorder(false)
+	table.SetRowLine(true)
+
+	for _, row := range tableModel.Rows {
+		table.Append(row)
+	}
+
+	table.SetFooter(tableModel.Footer)
+
+	table.Render()
+
+	for _, note := range tableModel.Notes {
+		fmt.Fprintln(w, note)
+	}
+
+	fmt.Fprintln(w, "")
+	return nil
+}

--- a/portfolio/render.go
+++ b/portfolio/render.go
@@ -2,11 +2,9 @@ package portfolio
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
 
-	tw "github.com/olekukonko/tablewriter"
 	"github.com/shopspring/decimal"
 
 	decimal_opt "github.com/tsiemens/acb/decimal_value"
@@ -219,28 +217,4 @@ func RenderAggregateCapitalGains(
 		[]string{"Since inception", ph.PlusMinusDollar(gains.CapitalGainsTotal, false)})
 
 	return table
-}
-
-func PrintRenderTable(title string, tableModel *RenderTable, writer io.Writer) {
-	for _, err := range tableModel.Errors {
-		fmt.Fprintf(writer, "[!] %v. Printing parsed information state:\n", err)
-	}
-	fmt.Fprintf(writer, "%s\n", title)
-
-	table := tw.NewWriter(writer)
-	table.SetHeader(tableModel.Header)
-	table.SetBorder(false)
-	table.SetRowLine(true)
-
-	for _, row := range tableModel.Rows {
-		table.Append(row)
-	}
-
-	table.SetFooter(tableModel.Footer)
-
-	table.Render()
-
-	for _, note := range tableModel.Notes {
-		fmt.Fprintln(writer, note)
-	}
 }

--- a/test/acb_app_test.go
+++ b/test/acb_app_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tsiemens/acb/app"
+	"github.com/tsiemens/acb/app/outfmt"
 	"github.com/tsiemens/acb/fx"
 	"github.com/tsiemens/acb/log"
 	ptf "github.com/tsiemens/acb/portfolio"
@@ -31,10 +32,12 @@ func makeCsvReader(desc string, lines ...string) app.DescribedReader {
 	return app.DescribedReader{Desc: desc, Reader: strings.NewReader(headerToUse + contents)}
 }
 
-func render(tableModel *ptf.RenderTable) {
+func render(tableModel *ptf.RenderTable) error {
 	if os.Getenv("VERBOSE") != "" {
-		ptf.PrintRenderTable("Dummy title", tableModel, os.Stdout)
+		w := outfmt.NewSTDWriter(os.Stdout)
+		return w.PrintRenderTable(outfmt.Transactions, "Dummy title", tableModel)
 	}
+	return nil
 }
 
 func splitCsvRows(fileLens []uint32, rows ...string) []app.DescribedReader {
@@ -59,7 +62,7 @@ func getAndCheckFooTable(rq *require.Assertions, rts map[string]*ptf.RenderTable
 	rq.Equal(1, len(rts))
 	renderTable := rts["FOO"]
 	rq.NotNil(renderTable)
-	render(renderTable)
+	rq.NoError(render(renderTable))
 	return renderTable
 }
 

--- a/www/wasm/main.go
+++ b/www/wasm/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall/js"
 
 	"github.com/tsiemens/acb/app"
+	"github.com/tsiemens/acb/app/outfmt"
 	"github.com/tsiemens/acb/fx"
 	ptf "github.com/tsiemens/acb/portfolio"
 )
@@ -145,18 +146,18 @@ func runAcb(
 
 	errPrinter := &BufErrorPrinter{}
 
-	var output strings.Builder
-
+	builder := &strings.Builder{}
+	writer := outfmt.NewSTDWriter(builder)
 	legacyOptions := app.NewLegacyOptions()
 
 	ok, renderRes := app.RunAcbAppToWriter(
-		&output,
+		writer,
 		csvReaders, allInitStatus, forceDownload, renderFullValues,
 		legacyOptions, &fx.MemRatesCacheAccessor{RatesByYear: globalRatesCache},
 		errPrinter,
 	)
 
-	outString := output.String()
+	outString := builder.String()
 
 	var secTables js.Value
 	var aggTable js.Value


### PR DESCRIPTION
This moves the PrintRenderTable function out of portfolio/render.go and into a new outfmt.ACBWriter implementation.

There is currently only the outfmt.STDWriter implementation, but there will be a CSV version in a subsequent change.

Apart from the unit tests, I also tested this against my own data and the result was identical, with the exception of a single extra newline after all of the output in the new version:

    --- /tmp/was.txt
    +++ /tmp/is.txt
    @@ -1266,3 +1266,4 @@
     ------------------+----------------
       Since inception | $...
     ------------------+----------------
    +