### PR TITLE
py: take an "--output-filename" arg for csv-to-xlsx, add new helper

### DIFF
--- a/py/csv-to-xlsx.py
+++ b/py/csv-to-xlsx.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 
-from posixpath import splitext
-from typing import Any, List, Callable, Tuple, Union
-import openpyxl
-from datetime import datetime
-from openpyxl.worksheet.worksheet import Worksheet
-from openpyxl.cell import Cell
+import argparse
 import sys
-from os.path import basename
 from csv import reader
+from datetime import datetime
+from os.path import basename
+from posixpath import splitext
+from typing import Any, Callable, List, Tuple, Union
+
+import openpyxl
+from openpyxl.cell import Cell
+from openpyxl.worksheet.worksheet import Worksheet
 
 DATE_FMT = "%Y-%m-%d"
 
@@ -69,14 +71,18 @@ def handle_file(wb: openpyxl.Workbook, name: str, sheet_num: int):
 
 
 def main():
-    files = sys.argv[1:]
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output-filename", default="out.xlsx")
+    ap.add_argument("files", metavar="CSV-FILE", nargs="+")
+    args = ap.parse_args()
+    files = sorted(args.files)
     if not files:
         return
 
     wb = openpyxl.Workbook(write_only=True)
-    for idx, fn in enumerate(sys.argv[1:]):
+    for idx, fn in enumerate(files):
         handle_file(wb, fn, idx + 1)
-    wb.save("out.xlsx")
+    wb.save(args.output_filename)
 
 
 if __name__ == "__main__":

--- a/py/normalize-csv-currency.py
+++ b/py/normalize-csv-currency.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+For a CSV file, find all cells that have a "$" in them and attempt to strip the
+currency symbol and all punctuation. Then round the output to two decimal places.
+
+The modified CSV file is printed to stdout.
+"""
+import re
+import sys
+from csv import reader, writer
+from datetime import datetime
+from decimal import Decimal, ROUND_HALF_EVEN
+
+DATE_FMT = "%Y-%m-%d"
+
+
+def convert(v: str) -> str | Decimal:
+    try:
+        return str(datetime.strptime(v, DATE_FMT))
+    except ValueError:
+        pass
+
+    if not v.strip().startswith("$"):
+        return v
+
+    try:
+        d = Decimal(re.sub(r"[$, ]", "", v))
+        return d.quantize(Decimal("0.01"), rounding=ROUND_HALF_EVEN)
+    except ValueError:
+        return v
+
+
+def main():
+    rows = []
+    with open(sys.argv[1]) as fp:
+        rd = reader(fp)
+
+        for row in rd:
+            rows.append([convert(i) for i in row])
+
+    wr = writer(sys.stdout)
+    wr.writerows(rows)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
csv-to-xlsx.py gets an `--output-filename` arg so that it doesn't have to write to `out.xlsx`.

The new helper is useful when comparing CSV files generated with different currency styles. Any cell that's a currency value will be rewritten starting with a "$", no commas or spaces, and rounded to two decimal places.