### PR TITLE
etrade: fix handling of ESO confirmation with multiple grants

### DIFF
--- a/src/portfolio/model/tx.rs
+++ b/src/portfolio/model/tx.rs
@@ -502,9 +502,10 @@ impl TryFrom<CsvTx> for Tx {
 
     fn try_from(csv_tx: CsvTx) -> Result<Self, Self::Error> {
         if csv_tx.action.is_none() {
-            return Err(
-                format!("\"action\" not specified. security: {:?}, trade date: {:?}",
-                    csv_tx.security, csv_tx.trade_date));
+            return Err(format!(
+                "\"action\" not specified. security: {:?}, trade date: {:?}",
+                csv_tx.security, csv_tx.trade_date
+            ));
         }
 
         let act_specs = match csv_tx.action.unwrap() {

--- a/src/util/decimal.rs
+++ b/src/util/decimal.rs
@@ -34,8 +34,10 @@ pub fn parse_large_decimal(s: &str) -> Result<Decimal, rust_decimal::Error> {
 
 pub fn dollar_precision_str(d: &Decimal) -> String {
     // Round to 2 decimal places, and format as a string.
-    let rounded = d.round_dp_with_strategy(2,
-        rust_decimal::RoundingStrategy::MidpointAwayFromZero);
+    let rounded = d.round_dp_with_strategy(
+        2,
+        rust_decimal::RoundingStrategy::MidpointAwayFromZero,
+    );
     format!("{:.2}", rounded)
 }
 


### PR DESCRIPTION
The assumed format was incorrect. It actually presents the multiple grants as separate columns with only a row prefix, that is, e.g.:

    Grant 1 Grant 2
    Grant Number 1234 1235

This is the reason `search_for_rows` had a `rowvalue2`. In theory, this could probably be extended to "n" Grant columns, but we don't have any test data for that case.