### PR TITLE
ci: check rustfmt when running tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,5 @@ jobs:
       run: make all-notest
     - name: Run tests
       run: cargo test --verbose
+    - name: Check formatting
+      run: make check-rustfmt

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ test-py:
 rustfmt:
 	rustfmt --config-path . `find src tests www -type f -name '*.rs'`
 
+check-rustfmt:
+	rustfmt --check --config-path . `find src tests www -type f -name '*.rs'`
+
 install:
 	cargo install --path .
 


### PR DESCRIPTION
I updated the push / pull_request CI job to run rustfmt --check so that we don't have to remember to do it manually before pushing.