### PR TITLE
Bump rawzip to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,9 +2299,9 @@ checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "rawzip"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56483ae996be55c2bdfd193157620e8f70608c76416a3a754fd2531ea7f437d"
+checksum = "15175d688c45677b5c1973398e0682a3efd381d3c7c0ccce86791d998986fac7"
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ json = "0.12.4"
 lazy_static = "1.4.0"
 office = { version = "0.8.1", optional = true }
 pdf-extract = { version = "0.7.7", optional = true }
-rawzip = "0.2.0"
+rawzip = "0.3.1"
 regex = "1.10.4"
 rust_decimal = "1.35.0"
 rust_decimal_macros = "1.34.2"

--- a/src/util/zip.rs
+++ b/src/util/zip.rs
@@ -47,13 +47,14 @@ impl ZipWriter {
         // in rawzip. Default file permission seems to be o664 (rw-rw-r--),
         // which is fine. Unfortunately though the modified date is set to 0,
         // so they all end up showing up as Dec 31 1979.
-        let options = rawzip::ZipEntryOptions::default()
-            .compression_method(rawzip::CompressionMethod::Store);
 
         // Start of a new file in our zip archive.
-        let entry_writer = self.archive.new_file(name, options).map_err(|e| {
-            format!("Failed to create new file in zip archive: {}", e)
-        })?;
+        let entry_writer = self.archive.new_file(name)
+            .compression_method(rawzip::CompressionMethod::Store)
+            .create()
+            .map_err(|e| {
+                format!("Failed to create new file in zip archive: {}", e)
+            })?;
 
         // We're not doing any compression so we can just use the raw file.
         // No need to wrap in an encoder.
@@ -109,7 +110,7 @@ mod tests {
             .map_err(|e| format!("No next entry: {e}"))?
             .unwrap();
 
-        assert_eq!(entry.file_safe_path().unwrap(), "file.txt");
+        assert_eq!(entry.file_path().try_normalize().unwrap().as_ref(), "file.txt");
 
         assert_eq!(entry.compression_method(), rawzip::CompressionMethod::Store);
 


### PR DESCRIPTION
btw, rawzip 0.3 includes the ability to write out files with timestamps if that is of interest -- instead of 1979/1980.