### PR TITLE
Add FHSA to list of registered accounts for Questrade script

### DIFF
--- a/src/peripheral/broker/questrade.rs
+++ b/src/peripheral/broker/questrade.rs
@@ -104,7 +104,7 @@ pub fn sheet_to_txs(
                 account_num,
             };
 
-            let affiliate = if regex::RegexBuilder::new(r"rrsp|tfsa|resp")
+            let affiliate = if regex::RegexBuilder::new(r"rrsp|tfsa|resp|fhsa")
                 .case_insensitive(true)
                 .build()
                 .unwrap()


### PR DESCRIPTION
Add FHSA to list of registered accounts. Right now it's counting as non-registered.

I tested manually with a questrade export.