### PR TITLE
Add fx rates caching for webapp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "acb",
  "async-trait",
  "regex",
+ "rust_decimal",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",

--- a/acb_wasm/Cargo.toml
+++ b/acb_wasm/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 acb = { path = "../", features = [ "wasm", "xlsx_read" ], default-features = false }
 async-trait = "0.1.80"
 regex = "1.10.4"
+rust_decimal = "1"
 serde-wasm-bindgen = "0.6.5"
 serde = "1.0.203"
 wasm-bindgen = "0.2.92"

--- a/acb_wasm/src/app_shim.rs
+++ b/acb_wasm/src/app_shim.rs
@@ -4,7 +4,6 @@ use serde::ser::SerializeStruct;
 
 use acb::{
     app::{outfmt::text::TextWriter, run_acb_app_to_writer},
-    fx::io::{InMemoryRatesCache, JsonRemoteRateLoader, RateLoader},
     portfolio::{io::tx_csv::TxCsvParseOptions, render::RenderTable, Security},
     util::{
         basic::SError,
@@ -12,19 +11,11 @@ use acb::{
     },
 };
 
-const FORCE_DOWNLOAD_RATES: bool = false;
-const RENDER_TOTAL_COSTS: bool = false;
+use crate::wasm_rates_loader::{
+    build_rates_cache_update, make_rate_loader, RatesCacheData, RatesCacheUpdate,
+};
 
-fn make_rate_loader(err_write_handle: WriteHandle) -> RateLoader {
-    RateLoader::new(
-        FORCE_DOWNLOAD_RATES,
-        Box::new(InMemoryRatesCache::new()),
-        JsonRemoteRateLoader::new_boxed(
-            crate::http::CorsEnabledHttpRequester::new_boxed(),
-        ),
-        err_write_handle,
-    )
-}
+const RENDER_TOTAL_COSTS: bool = false;
 
 pub struct SerializableRenderTable(pub RenderTable);
 
@@ -66,6 +57,7 @@ impl serde::ser::Serialize for AppRenderResult {
 pub struct AppResultOk {
     pub text_output: String,
     pub model_output: AppRenderResult,
+    pub rates_cache_update: RatesCacheUpdate,
 }
 
 impl serde::ser::Serialize for AppResultOk {
@@ -75,10 +67,11 @@ impl serde::ser::Serialize for AppResultOk {
     {
         // https://serde.rs/impl-serialize.html
 
-        let n_fields = 2;
+        let n_fields = 3;
         let mut state = serializer.serialize_struct("AppResultOk", n_fields)?;
         state.serialize_field("textOutput", &self.text_output)?;
         state.serialize_field("modelOutput", &self.model_output)?;
+        state.serialize_field("ratesCacheUpdate", &self.rates_cache_update)?;
         state.end()
     }
 }
@@ -86,6 +79,7 @@ impl serde::ser::Serialize for AppResultOk {
 pub async fn run_acb_app(
     csv_file_readers: Vec<DescribedReader>,
     render_full_dollar_values: bool,
+    initial_rates: Option<&RatesCacheData>,
 ) -> Result<AppResultOk, SError> {
     let (out_write_handle, out_string_buff) =
         WriteHandle::string_buff_write_handle();
@@ -94,7 +88,7 @@ pub async fn run_acb_app(
 
     let writer = Box::new(TextWriter::new(out_write_handle));
 
-    let rate_loader = make_rate_loader(err_write_handle.clone());
+    let mut rate_loader = make_rate_loader(err_write_handle.clone(), initial_rates)?;
 
     let result = run_acb_app_to_writer(
         writer,
@@ -102,10 +96,12 @@ pub async fn run_acb_app(
         &TxCsvParseOptions::default(),
         render_full_dollar_values,
         RENDER_TOTAL_COSTS,
-        rate_loader,
+        &mut rate_loader,
         err_write_handle,
     )
     .await;
+
+    let rates_cache_update = build_rates_cache_update(&mut rate_loader);
 
     match result {
         Ok(r) => Ok(AppResultOk {
@@ -120,6 +116,7 @@ pub async fn run_acb_app(
                     r.aggregate_gains_table,
                 ),
             },
+            rates_cache_update,
         }),
         Err(()) => {
             let error_string =
@@ -162,6 +159,7 @@ impl serde::ser::Serialize for FileContent {
 
 pub struct AppExportResultOk {
     pub csv_files: Vec<FileContent>,
+    pub rates_cache_update: RatesCacheUpdate,
 }
 
 impl serde::ser::Serialize for AppExportResultOk {
@@ -171,10 +169,11 @@ impl serde::ser::Serialize for AppExportResultOk {
     {
         // https://serde.rs/impl-serialize.html
 
-        let n_fields = 1;
+        let n_fields = 2;
         let mut state =
             serializer.serialize_struct("AppExportResultOk", n_fields)?;
         state.serialize_field("csvFiles", &self.csv_files)?;
+        state.serialize_field("ratesCacheUpdate", &self.rates_cache_update)?;
         state.end()
     }
 }
@@ -182,6 +181,7 @@ impl serde::ser::Serialize for AppExportResultOk {
 pub async fn run_acb_app_for_export(
     csv_file_readers: Vec<DescribedReader>,
     render_full_dollar_values: bool,
+    initial_rates: Option<&RatesCacheData>,
 ) -> Result<AppExportResultOk, SError> {
     let (err_write_handle, err_string_buff) =
         WriteHandle::string_buff_write_handle();
@@ -192,7 +192,7 @@ pub async fn run_acb_app_for_export(
         csv_coll.clone(),
     ));
 
-    let rate_loader = make_rate_loader(err_write_handle.clone());
+    let mut rate_loader = make_rate_loader(err_write_handle.clone(), initial_rates)?;
 
     let result = run_acb_app_to_writer(
         writer,
@@ -200,14 +200,17 @@ pub async fn run_acb_app_for_export(
         &TxCsvParseOptions::default(),
         render_full_dollar_values,
         RENDER_TOTAL_COSTS,
-        rate_loader,
+        &mut rate_loader,
         err_write_handle,
     )
     .await;
 
+    let rates_cache_update = build_rates_cache_update(&mut rate_loader);
+
     match result {
         Ok(_) => Ok(AppExportResultOk {
             csv_files: csv_coll.take().into_iter().map(FileContent::from).collect(),
+            rates_cache_update,
         }),
         Err(()) => {
             let error_string =
@@ -301,6 +304,7 @@ impl serde::ser::Serialize for EtradeExtractResult {
 pub struct AppSummaryResultOk {
     pub csv_text: String,
     pub summary_table: SerializableRenderTable,
+    pub rates_cache_update: RatesCacheUpdate,
 }
 
 impl serde::ser::Serialize for AppSummaryResultOk {
@@ -308,11 +312,12 @@ impl serde::ser::Serialize for AppSummaryResultOk {
     where
         S: serde::ser::Serializer,
     {
-        let n_fields = 2;
+        let n_fields = 3;
         let mut state =
             serializer.serialize_struct("AppSummaryResultOk", n_fields)?;
         state.serialize_field("csvText", &self.csv_text)?;
         state.serialize_field("summaryTable", &self.summary_table)?;
+        state.serialize_field("ratesCacheUpdate", &self.rates_cache_update)?;
         state.end()
     }
 }
@@ -322,13 +327,14 @@ pub async fn run_acb_app_summary(
     csv_file_readers: Vec<DescribedReader>,
     split_annual_summary_gains: bool,
     render_full_dollar_values: bool,
+    initial_rates: Option<&RatesCacheData>,
 ) -> Result<AppSummaryResultOk, SError> {
     use acb::app::{run_acb_app_summary_to_render_model, Options};
 
     let (err_write_handle, err_string_buff) =
         WriteHandle::string_buff_write_handle();
 
-    let rate_loader = make_rate_loader(err_write_handle.clone());
+    let mut rate_loader = make_rate_loader(err_write_handle.clone(), initial_rates)?;
 
     let options = Options {
         render_full_dollar_values,
@@ -340,10 +346,12 @@ pub async fn run_acb_app_summary(
         latest_date,
         csv_file_readers,
         options,
-        rate_loader,
+        &mut rate_loader,
         err_write_handle,
     )
     .await;
+
+    let rates_cache_update = build_rates_cache_update(&mut rate_loader);
 
     let buffered_error_string =
         err_string_buff.try_borrow_mut().unwrap().export_string();
@@ -375,5 +383,6 @@ pub async fn run_acb_app_summary(
     Ok(AppSummaryResultOk {
         csv_text: result.csv_text,
         summary_table,
+        rates_cache_update,
     })
 }

--- a/acb_wasm/src/lib.rs
+++ b/acb_wasm/src/lib.rs
@@ -5,6 +5,7 @@ use wasm_bindgen::prelude::*;
 
 pub mod app_shim;
 pub mod http;
+pub mod wasm_rates_loader;
 
 /// Convert a raw Excel workbook (as bytes) to ACB-format CSV text.
 ///
@@ -256,6 +257,23 @@ pub fn extract_etrade_pdf_data(
     Ok(serde_wasm_bindgen::to_value(&extract_result)?)
 }
 
+fn parse_initial_rates(
+    initial_rates_cache: JsValue,
+) -> Result<Option<wasm_rates_loader::RatesCacheData>, JsValue> {
+    if initial_rates_cache.is_undefined() || initial_rates_cache.is_null() {
+        Ok(None)
+    } else {
+        Ok(Some(
+            serde_wasm_bindgen::from_value(initial_rates_cache).map_err(|e| {
+                JsValue::from_str(&format!(
+                    "Failed to deserialize rates cache: {}",
+                    e
+                ))
+            })?,
+        ))
+    }
+}
+
 fn get_csv_readers(
     file_descs: Vec<String>,
     file_contents: Vec<String>,
@@ -278,20 +296,29 @@ pub async fn run_acb(
     file_contents: Vec<String>,
     render_full_values: bool,
     export_mode: bool,
+    initial_rates_cache: JsValue,
 ) -> Result<JsValue, JsValue> {
     let csv_readers = get_csv_readers(file_descs, file_contents)?;
+    let initial_rates = parse_initial_rates(initial_rates_cache)?;
 
     if export_mode {
-        let result =
-            app_shim::run_acb_app_for_export(csv_readers, render_full_values)
-                .await
-                .map_err(|e| JsValue::from_str(&e))?;
+        let result = app_shim::run_acb_app_for_export(
+            csv_readers,
+            render_full_values,
+            initial_rates.as_ref(),
+        )
+        .await
+        .map_err(|e| JsValue::from_str(&e))?;
         return Ok(serde_wasm_bindgen::to_value(&result)?);
     }
 
-    let result = app_shim::run_acb_app(csv_readers, render_full_values)
-        .await
-        .map_err(|e| JsValue::from_str(&e))?;
+    let result = app_shim::run_acb_app(
+        csv_readers,
+        render_full_values,
+        initial_rates.as_ref(),
+    )
+    .await
+    .map_err(|e| JsValue::from_str(&e))?;
 
     Ok(serde_wasm_bindgen::to_value(&result)?)
 }
@@ -303,8 +330,10 @@ pub async fn run_acb_summary(
     file_contents: Vec<String>,
     split_annual_summary_gains: bool,
     render_full_values: bool,
+    initial_rates_cache: JsValue,
 ) -> Result<JsValue, JsValue> {
     let csv_readers = get_csv_readers(file_descs, file_contents)?;
+    let initial_rates = parse_initial_rates(initial_rates_cache)?;
 
     let latest_date_rs = acb::util::date::from_date_ints(
         latest_date.get_full_year() as i32,
@@ -320,6 +349,7 @@ pub async fn run_acb_summary(
         csv_readers,
         split_annual_summary_gains,
         render_full_values,
+        initial_rates.as_ref(),
     )
     .await
     .map_err(|e| JsValue::from_str(&e))?;

--- a/acb_wasm/src/wasm_rates_loader.rs
+++ b/acb_wasm/src/wasm_rates_loader.rs
@@ -1,0 +1,115 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use acb::{
+    fx::{
+        io::{InMemoryRatesCache, JsonRemoteRateLoader, RateLoader},
+        DailyRate,
+    },
+    util::{basic::SError, rw::WriteHandle},
+};
+
+const FORCE_DOWNLOAD_RATES: bool = false;
+
+// -- Serializable interchange types for browser-cached FX rates --
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SerializableDailyRate {
+    pub date: String,
+    pub rate: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SerializableYearRates {
+    pub year: u32,
+    pub rates: Vec<SerializableDailyRate>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct RatesCacheData {
+    pub years: Vec<SerializableYearRates>,
+}
+
+#[derive(Serialize, Clone, Debug, Default)]
+pub struct RatesCacheUpdate {
+    pub years: Vec<SerializableYearRates>,
+}
+
+fn daily_rates_to_serializable(rates: &[DailyRate]) -> Vec<SerializableDailyRate> {
+    rates
+        .iter()
+        .map(|r| SerializableDailyRate {
+            date: r.date.to_string(),
+            rate: r.foreign_to_local_rate.to_string(),
+        })
+        .collect()
+}
+
+fn serializable_to_daily_rates(
+    rates: &[SerializableDailyRate],
+) -> Result<Vec<DailyRate>, SError> {
+    use rust_decimal::Decimal;
+    use std::str::FromStr;
+
+    rates
+        .iter()
+        .map(|r| {
+            let date = acb::util::date::parse_standard_date(&r.date)
+                .map_err(|e| format!("Invalid date '{}': {}", r.date, e))?;
+            let rate = Decimal::from_str(&r.rate)
+                .map_err(|e| format!("Invalid rate '{}': {}", r.rate, e))?;
+            Ok(DailyRate {
+                date,
+                foreign_to_local_rate: rate,
+            })
+        })
+        .collect()
+}
+
+fn deserialize_initial_rates(
+    data: &RatesCacheData,
+) -> Result<HashMap<u32, Vec<DailyRate>>, SError> {
+    let mut map = HashMap::new();
+    for yr in &data.years {
+        let rates = serializable_to_daily_rates(&yr.rates)?;
+        map.insert(yr.year, rates);
+    }
+    Ok(map)
+}
+
+pub fn make_rate_loader(
+    err_write_handle: WriteHandle,
+    initial_rates: Option<&RatesCacheData>,
+) -> Result<RateLoader, SError> {
+    let cache = if let Some(data) = initial_rates {
+        InMemoryRatesCache::new_with_rates(deserialize_initial_rates(data)?)
+    } else {
+        InMemoryRatesCache::new()
+    };
+
+    Ok(RateLoader::new(
+        FORCE_DOWNLOAD_RATES,
+        Box::new(cache),
+        JsonRemoteRateLoader::new_boxed(
+            crate::http::CorsEnabledHttpRequester::new_boxed(),
+        ),
+        err_write_handle,
+    ))
+}
+
+pub fn build_rates_cache_update(rate_loader: &mut RateLoader) -> RatesCacheUpdate {
+    let fresh_years: Vec<u32> =
+        rate_loader.fresh_loaded_years().iter().copied().collect();
+    let mut years = Vec::new();
+    for year in &fresh_years {
+        if let Ok(Some(rates)) = rate_loader.cache.get_usd_cad_rates(*year) {
+            years.push(SerializableYearRates {
+                year: *year,
+                rates: daily_rates_to_serializable(&rates),
+            });
+        }
+    }
+    years.sort_by_key(|y| y.year);
+    RatesCacheUpdate { years }
+}

--- a/src/app/approot.rs
+++ b/src/app/approot.rs
@@ -63,7 +63,7 @@ impl Default for Options {
 pub async fn run_acb_app_to_delta_models(
     csv_file_readers: Vec<DescribedReader>,
     csv_parse_options: &TxCsvParseOptions,
-    mut rate_loader: RateLoader,
+    rate_loader: &mut RateLoader,
     mut err_printer: WriteHandle,
 ) -> Result<HashMap<Security, DeltaListResult>, Error> {
     let mut all_txs = Vec::<Tx>::new();
@@ -76,7 +76,7 @@ pub async fn run_acb_app_to_delta_models(
             &mut err_printer,
         )?;
 
-        load_tx_rates(&mut csv_txs, &mut rate_loader).await?;
+        load_tx_rates(&mut csv_txs, rate_loader).await?;
 
         let mut txs = Vec::<Tx>::with_capacity(csv_txs.len());
         for csv_tx in csv_txs {
@@ -169,7 +169,7 @@ pub async fn run_acb_app_summary_to_render_model(
     latest_date: Date,
     csv_file_readers: Vec<DescribedReader>,
     options: Options,
-    rate_loader: RateLoader,
+    rate_loader: &mut RateLoader,
     err_printer: WriteHandle,
 ) -> AppSummaryRenderResult {
     let res = run_acb_app_summary_to_model(
@@ -219,7 +219,7 @@ pub async fn run_acb_app_to_render_model(
     csv_parse_options: &TxCsvParseOptions,
     render_full_dollar_values: bool,
     render_total_costs: bool,
-    rate_loader: RateLoader,
+    rate_loader: &mut RateLoader,
     err_printer: WriteHandle,
 ) -> Result<AppRenderResult, Error> {
     let deltas_results_by_sec = run_acb_app_to_delta_models(
@@ -339,7 +339,7 @@ pub async fn run_acb_app_to_writer(
     csv_parse_options: &TxCsvParseOptions,
     render_full_dollar_values: bool,
     render_total_costs: bool,
-    rate_loader: RateLoader,
+    rate_loader: &mut RateLoader,
     mut err_printer: WriteHandle,
 ) -> Result<AppRenderResult, ()> {
     let res = run_acb_app_to_render_model(
@@ -377,7 +377,7 @@ pub async fn run_acb_app_summary_to_model(
     latest_date: Date,
     csv_file_readers: Vec<DescribedReader>,
     options: Options,
-    rate_loader: RateLoader,
+    rate_loader: &mut RateLoader,
     err_printer: WriteHandle,
 ) -> Result<CollectedSummaryData, AppSummaryError> {
     let deltas_results_by_sec = run_acb_app_to_delta_models(
@@ -423,7 +423,7 @@ pub async fn run_acb_app_summary_to_console(
     latest_date: Date,
     csv_file_readers: Vec<DescribedReader>,
     options: Options,
-    rate_loader: RateLoader,
+    rate_loader: &mut RateLoader,
     mut err_printer: WriteHandle,
 ) -> Result<(), ()> {
     let summ_res = run_acb_app_summary_to_model(
@@ -477,7 +477,7 @@ pub async fn run_acb_app_summary_to_console(
 pub async fn run_acb_app_to_console(
     csv_file_readers: Vec<DescribedReader>,
     options: Options,
-    rate_loader: RateLoader,
+    rate_loader: &mut RateLoader,
     mut err_printer: WriteHandle,
 ) -> Result<(), ()> {
     if let Some(summary_mode_latest_date) = options.summary_mode_latest_date {
@@ -603,7 +603,7 @@ mod tests {
             &TxCsvParseOptions::default(),
             false,
             render_costs,
-            make_empty_test_rate_loader(),
+            &mut make_empty_test_rate_loader(),
             WriteHandle::empty_write_handle(),
         ))
         .unwrap();
@@ -635,7 +635,7 @@ mod tests {
             &TxCsvParseOptions::default(),
             false,
             render_costs,
-            make_empty_test_rate_loader(),
+            &mut make_empty_test_rate_loader(),
             WriteHandle::empty_write_handle(),
         ))
         .unwrap();
@@ -673,7 +673,7 @@ mod tests {
             &TxCsvParseOptions::default(),
             false,
             render_costs,
-            make_empty_test_rate_loader(),
+            &mut make_empty_test_rate_loader(),
             WriteHandle::empty_write_handle(),
         ))
         .unwrap();
@@ -720,7 +720,7 @@ mod tests {
             &TxCsvParseOptions::default(),
             false,
             false,
-            make_empty_test_rate_loader(),
+            &mut make_empty_test_rate_loader(),
             WriteHandle::empty_write_handle(),
         ))
         .unwrap();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -154,7 +154,7 @@ pub fn command_main() -> Result<(), ExitCode> {
         }
     };
 
-    let rate_loader = RateLoader::new(
+    let mut rate_loader = RateLoader::new(
         args.force_download,
         Box::new(CsvRatesCache::new(home_dir, err_printer.clone())),
         JsonRemoteRateLoader::new_boxed(StandaloneAppRequester::new_boxed()),
@@ -164,7 +164,7 @@ pub fn command_main() -> Result<(), ExitCode> {
     async_std::task::block_on(run_acb_app_to_console(
         csv_readers,
         options,
-        rate_loader,
+        &mut rate_loader,
         err_printer,
     ))
     .map_err(|_| ExitCode::FAILURE)

--- a/src/fx/io/rate_loader.rs
+++ b/src/fx/io/rate_loader.rs
@@ -43,6 +43,10 @@ impl RateLoader {
         }
     }
 
+    pub fn fresh_loaded_years(&self) -> &HashSet<u32> {
+        &self.fresh_loaded_years
+    }
+
     pub fn new_cached_remote_loader(
         force_download: bool,
         cache: Box<dyn RatesCache>,

--- a/src/fx/io/rates_cache.rs
+++ b/src/fx/io/rates_cache.rs
@@ -30,6 +30,14 @@ impl InMemoryRatesCache {
             rates_by_year: RcRefCellT::new(HashMap::new()),
         }
     }
+
+    pub fn new_with_rates(
+        rates_by_year: HashMap<u32, Vec<DailyRate>>,
+    ) -> InMemoryRatesCache {
+        InMemoryRatesCache {
+            rates_by_year: RcRefCellT::new(rates_by_year),
+        }
+    }
 }
 
 impl RatesCache for InMemoryRatesCache {

--- a/tests/sample_files_test.rs
+++ b/tests/sample_files_test.rs
@@ -28,21 +28,23 @@ fn validate_sample_csv_file(
     let (write_handle, buff) = WriteHandle::string_buff_write_handle();
     let writer = Box::new(TextWriter::new(write_handle));
 
+    let mut rate_loader = RateLoader::new(
+        false,
+        Box::new(CsvRatesCache::new(
+            cache_dir.to_path_buf(),
+            err_stream.clone(),
+        )),
+        JsonRemoteRateLoader::new_boxed(StandaloneAppRequester::new_boxed()),
+        err_stream.clone(),
+    );
+
     let res = async_std::task::block_on(run_acb_app_to_writer(
         writer,
         vec![reader],
         &TxCsvParseOptions::default(),
         false,
         render_costs,
-        RateLoader::new(
-            false,
-            Box::new(CsvRatesCache::new(
-                cache_dir.to_path_buf(),
-                err_stream.clone(),
-            )),
-            JsonRemoteRateLoader::new_boxed(StandaloneAppRequester::new_boxed()),
-            err_stream.clone(),
-        ),
+        &mut rate_loader,
         err_stream.clone(),
     ));
 
@@ -113,18 +115,20 @@ fn test_sample_csv_parse_errors() {
     let (write_handle, _buff) = WriteHandle::string_buff_write_handle();
     let writer = Box::new(TextWriter::new(write_handle));
 
+    let mut rate_loader = RateLoader::new(
+        false,
+        Box::new(CsvRatesCache::new(dir.path.clone(), err_stream.clone())),
+        JsonRemoteRateLoader::new_boxed(StandaloneAppRequester::new_boxed()),
+        err_stream.clone(),
+    );
+
     let res = async_std::task::block_on(run_acb_app_to_writer(
         writer,
         vec![reader],
         &TxCsvParseOptions::default(),
         false,
         false,
-        RateLoader::new(
-            false,
-            Box::new(CsvRatesCache::new(dir.path.clone(), err_stream.clone())),
-            JsonRemoteRateLoader::new_boxed(StandaloneAppRequester::new_boxed()),
-            err_stream.clone(),
-        ),
+        &mut rate_loader,
         err_stream,
     ));
 

--- a/www/src/acb_app.ts
+++ b/www/src/acb_app.ts
@@ -4,12 +4,19 @@ import { fileBytesToString, loadFilesAsBytes } from "./file_reader.js";
 import { FileEntry, FileKind, getFileManagerStore, modifyDrawerNotificationForUserAddedFiles } from './vue/file_manager_store.js';
 import { run_acb, run_acb_summary, detect_file_kind, detect_file_kind_from_pdf_pages } from './pkg/acb_wasm.js';
 import { Result } from "./result.js";
-import { AppExportResultOk, AppResultOk, AppSummaryResultOk, RenderTable } from "./acb_wasm_types.js";
+import { AppExportResultOk, AppResultOk, AppSummaryResultOk, RatesCacheUpdate, RenderTable } from "./acb_wasm_types.js";
+import { loadRatesCache, mergeRatesCacheUpdate } from "./rates_cache.js";
 import { getOutputStore, setAppFunctionViewMode } from "./vue/output_store.js";
 import { getAppInputStore, getSummaryDate } from "./vue/app_input_store.js";
 import { ErrorBox } from "./vue/error_box_store.js";
 import { downloadCsv, makeZipAndDownload } from "./download_utils.js";
 import { extractPdfPages } from "./pdf_text_util.js";
+
+function maybeMergeRatesCacheUpdate(update?: RatesCacheUpdate): void {
+   if (update) {
+      mergeRatesCacheUpdate(update);
+   }
+}
 
 class CommonRunOptions {
    constructor(
@@ -34,20 +41,23 @@ async function asyncRunAcb(filenames: string[], contents: string[],
    const { printFullDollarValues } = commonOptions.unwrap();
 
    const exportMode: boolean = mode === AcbAppRunMode.Export;
+   const cachedRates = loadRatesCache();
 
    try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
       const jsRet: any = await run_acb(filenames, contents,
-         printFullDollarValues, exportMode);
+         printFullDollarValues, exportMode, cachedRates);
       console.debug("asyncRunAcb: run_acb returned: ", jsRet);
 
       if (exportMode) {
          const ret = AppExportResultOk.fromJsValue(jsRet);
+         maybeMergeRatesCacheUpdate(ret.ratesCacheUpdate);
          makeZipAndDownload(ret.csvFiles);
          return;
       }
 
       const ret: AppResultOk = AppResultOk.fromJsValue(jsRet);
+      maybeMergeRatesCacheUpdate(ret.ratesCacheUpdate);
 
       setAppFunctionViewMode(AppFunctionMode.Calculate);
 
@@ -80,14 +90,17 @@ async function asyncRunAcbSummary(filenames: string[], contents: string[], lates
 
    // Also, pass split_annual_summary_gains as true (or add UI for it if needed).
    const splitAnnualSummaryGains = true;
+   const cachedRates = loadRatesCache();
 
    try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
       const jsRet: any = await run_acb_summary(
-         latestDate, filenames, contents, splitAnnualSummaryGains, printFullDollarValues
+         latestDate, filenames, contents, splitAnnualSummaryGains, printFullDollarValues,
+         cachedRates
       );
       console.debug("asyncRunAcbSummary: run_acb_summary returned: ", jsRet);
       const ret: AppSummaryResultOk = AppSummaryResultOk.fromJsValue(jsRet);
+      maybeMergeRatesCacheUpdate(ret.ratesCacheUpdate);
 
       if (mode === AcbAppRunMode.Export) {
          downloadCsv("acb_summary", ret.csvText);
@@ -153,14 +166,17 @@ async function asyncRunAcbShareTally(filenames: string[], contents: string[], la
    const { printFullDollarValues } = commonOptions.unwrap();
 
    const splitAnnualSummaryGains = false;
+   const cachedRates = loadRatesCache();
 
    try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
       const jsRet: any = await run_acb_summary(
-         latestDate, filenames, contents, splitAnnualSummaryGains, printFullDollarValues
+         latestDate, filenames, contents, splitAnnualSummaryGains, printFullDollarValues,
+         cachedRates
       );
       console.debug("asyncRunAcbShareTally: run_acb_summary returned: ", jsRet);
       const ret: AppSummaryResultOk = AppSummaryResultOk.fromJsValue(jsRet);
+      maybeMergeRatesCacheUpdate(ret.ratesCacheUpdate);
 
       const [shareTallyTable, csvText] = generateShareTallyRenderTable(ret.summaryTable);
 

--- a/www/src/acb_wasm_types.ts
+++ b/www/src/acb_wasm_types.ts
@@ -1,5 +1,25 @@
 import { mustGet, get } from "./basic_utils.js";
 
+// -- FX Rates Cache interchange types --
+
+export interface SerializableDailyRate {
+   date: string;
+   rate: string;
+}
+
+export interface SerializableYearRates {
+   year: number;
+   rates: SerializableDailyRate[];
+}
+
+export interface RatesCacheData {
+   years: SerializableYearRates[];
+}
+
+export interface RatesCacheUpdate {
+   years: SerializableYearRates[];
+}
+
 // Replication of AppResultOk in app_shim.rs:
 
 export class RenderTable {
@@ -87,6 +107,7 @@ export class AppResultOk {
     constructor(
         public textOutput: string,
         public modelOutput: AppRenderResult,
+        public ratesCacheUpdate?: RatesCacheUpdate,
     ) {}
 
     /* Import type from wasm interface */
@@ -95,6 +116,7 @@ export class AppResultOk {
         return new AppResultOk(
             mustGet(val, 'textOutput'),
             AppRenderResult.fromJsValue(mustGet(val, 'modelOutput')),
+            get(val, 'ratesCacheUpdate') as RatesCacheUpdate | undefined,
         );
     }
 
@@ -124,6 +146,7 @@ export class FileContent {
 export class AppExportResultOk {
     constructor(
         public csvFiles: Array<FileContent>,
+        public ratesCacheUpdate?: RatesCacheUpdate,
     ) {}
 
     /* Import type from wasm interface */
@@ -132,6 +155,7 @@ export class AppExportResultOk {
         return new AppExportResultOk(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             mustGet<any[]>(val, 'csvFiles').map(FileContent.fromJsValue),
+            get(val, 'ratesCacheUpdate') as RatesCacheUpdate | undefined,
         );
     }
 
@@ -146,6 +170,7 @@ export class AppSummaryResultOk {
     constructor(
         public csvText: string,
         public summaryTable: RenderTable,
+        public ratesCacheUpdate?: RatesCacheUpdate,
     ) {}
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -153,6 +178,7 @@ export class AppSummaryResultOk {
         return new AppSummaryResultOk(
             mustGet(val, 'csvText'),
             RenderTable.fromJsValue(mustGet(val, 'summaryTable')),
+            get(val, 'ratesCacheUpdate') as RatesCacheUpdate | undefined,
         );
     }
 

--- a/www/src/rates_cache.ts
+++ b/www/src/rates_cache.ts
@@ -1,0 +1,48 @@
+import { ref } from "vue";
+import { RatesCacheUpdate, RatesCacheData } from "./acb_wasm_types.js";
+
+const STORAGE_KEY = "acb_usd_fx_rates_cache";
+
+/** Reactive flag tracking whether a rates cache exists in localStorage. */
+export const ratesCacheExists = ref(localStorage.getItem(STORAGE_KEY) !== null);
+
+export function loadRatesCache(): RatesCacheData | undefined {
+   try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return undefined;
+      return JSON.parse(raw) as RatesCacheData;
+   } catch (e) {
+      console.warn("Failed to load FX rates cache from localStorage:", e);
+      return undefined;
+   }
+}
+
+export function mergeRatesCacheUpdate(update: RatesCacheUpdate): void {
+   if (update.years.length === 0) return;
+
+   try {
+      const existing = loadRatesCache() ?? { years: [] };
+      const yearMap = new Map<number, RatesCacheUpdate["years"][number]>();
+
+      for (const yr of existing.years) {
+         yearMap.set(yr.year, yr);
+      }
+      // Overwrite with freshly-downloaded years
+      for (const yr of update.years) {
+         yearMap.set(yr.year, yr);
+      }
+
+      const merged: RatesCacheData = {
+         years: Array.from(yearMap.values()).sort((a, b) => a.year - b.year),
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
+      ratesCacheExists.value = true;
+   } catch (e) {
+      console.warn("Failed to save FX rates cache to localStorage:", e);
+   }
+}
+
+export function clearRatesCache(): void {
+   localStorage.removeItem(STORAGE_KEY);
+   ratesCacheExists.value = false;
+}

--- a/www/src/vue/Sidebar.vue
+++ b/www/src/vue/Sidebar.vue
@@ -17,6 +17,15 @@
           <label for="printFullValuesCheckbox">Render high-precision dollars</label>
         </div>
       </div>
+
+      <div class="option-group">
+        <button
+          class="clear-cache-btn"
+          title="Clear the browser-cached FX exchange rates. Rates will be re-downloaded on the next run."
+          :disabled="!ratesCacheExists"
+          @click="onClearRatesCache"
+        >Clear FX Rates Cache</button>
+      </div>
     </div>
 
     <div v-if="tabStore.activeTab === TabId.BrokerConvert" class="options-section">
@@ -96,6 +105,7 @@ import { getSidebarInfoStore } from './sidebar_info_store.js';
 import { getAppInputStore } from './app_input_store.js';
 import { getTabStore, TabId } from './tab_store.js';
 import { isDebugModeEnabled } from '../debug.js';
+import { clearRatesCache, ratesCacheExists } from '../rates_cache.js';
 
 export default defineComponent({
    name: 'Sidebar',
@@ -126,10 +136,15 @@ export default defineComponent({
          appInputStore.filterYear = (event.target as HTMLInputElement).value;
       }
 
+      function onClearRatesCache() {
+         clearRatesCache();
+      }
+
       return {
          sidebarInfoStore, appInputStore, tabStore, TabId, isDebugMode,
+         ratesCacheExists,
          onPrintFullChange, onPairStcChange, onExtractOnlyChange, onNoFxChange,
-         onFilterYearInput,
+         onFilterYearInput, onClearRatesCache,
       };
    },
 });
@@ -163,5 +178,23 @@ export default defineComponent({
   padding: 8px;
   border: 1px solid #ddd;
   border-radius: 4px;
+}
+
+.clear-cache-btn {
+  padding: 6px 12px;
+  font-size: 0.85em;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #f5f5f5;
+  cursor: pointer;
+}
+
+.clear-cache-btn:hover:not(:disabled) {
+  background-color: #e8e8e8;
+}
+
+.clear-cache-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 </style>


### PR DESCRIPTION
Browser can now cache usd-cad exchange rates. Requests are still done from the rust RatesLoader.

Fixes #86 