### PR TITLE
Support Questrade DRIP transcations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Most/all of the complex scripts are also compiled into `target/...` or your carg
 - tx-export-convert: Convert exported transaction spreadsheets to acb-compatible csv files (Questrade-only for now)
 - etrade-plan-pdf-tx-extract: Generate acb csv files from ETRADE stock plan PDFs.
 
+#### Questrade DRIP transactions
+`tx-export-convert` supports Questrade dividend reinvestment (`REI`) rows by converting them to `Buy` transactions. When Questrade reports a zero price for the reinvestment, the converter derives the effective price from the absolute net amount divided by the share quantity.
+
+Questrade may report DRIP rows with an internal symbol instead of the traded security symbol. In that case, the converter resolves the symbol from a matching security description in a `BUY` or `SELL` row from the same export. If no match is available, include a matching trade row for that security in the export before converting it.
+
 ## Example
 
 A csv file like so:

--- a/src/peripheral/broker/questrade.rs
+++ b/src/peripheral/broker/questrade.rs
@@ -44,8 +44,12 @@ pub fn sheet_to_txs(
         .into_iter(),
     );
     let allowed_actions: HashSet<&'static str> = HashSet::from_iter(
-        vec!["BUY", "SELL", "DIS", "LIQ", "FXT", "DIV", "CIL"].into_iter(),
+        vec!["BUY", "SELL", "DIS", "LIQ", "FXT", "DIV", "CIL", "REI"].into_iter(),
     );
+
+    // Questrade reports DRIP/REI rows with an internal symbol, so build a
+    // description-to-symbol index from ordinary trades in the same export.
+    let desc_symbol_aliases = build_desc_symbol_aliases(sheet);
 
     let mut fx_tracker = FxTracker::new();
 
@@ -63,6 +67,7 @@ pub fn sheet_to_txs(
     let mut txs = Vec::<BrokerTx>::new();
 
     let mut errors = Vec::<SheetParseError>::new();
+    let mut fatal_error = false;
 
     let mut row_num = 0;
     for row in sheet.rows() {
@@ -144,6 +149,7 @@ pub fn sheet_to_txs(
                 return Ok(());
             }
 
+            let description = reader.get_str("Description")?;
             let mut converted_action_note = String::new();
             let action = match action_str.as_str() {
                 "BUY" => TxAction::Buy,
@@ -159,6 +165,12 @@ pub fn sheet_to_txs(
                     converted_action_note = "; From LIQ action.".to_string();
                     TxAction::Sell
                 }
+                "REI" => {
+                    // Treat dividend reinvestments as buys using the effective
+                    // per-share price implied by the reinvested amount.
+                    converted_action_note = "; From REI action.".to_string();
+                    TxAction::Buy
+                }
                 _ => {
                     // This should never happen in practice, if we handle all
                     // allowed actions above.
@@ -169,15 +181,57 @@ pub fn sheet_to_txs(
                 }
             };
 
-            let (symbol, orig_symbol_note) = if let Some((alias, aka)) =
-                symbol_aliases.get(pre_alias_symbol.as_str())
+            let (resolved_symbol, resolved_from_description) = if action_str == "REI"
             {
-                (alias.to_string(), format!("; {pre_alias_symbol} AKA {aka}"))
+                let lookup_desc = normalize_symbol_lookup_desc(&description);
+                if let Some(symbol) = desc_symbol_aliases.get(&lookup_desc) {
+                    (symbol.clone(), true)
+                } else if symbol_aliases.contains_key(pre_alias_symbol.as_str()) {
+                    // Some Questrade placeholder symbols are already known
+                    // manual aliases, so they do not need description lookup.
+                    (pre_alias_symbol.clone(), false)
+                } else {
+                    // Producing partial output here would silently carry the
+                    // broker's internal placeholder symbol into the portfolio.
+                    fatal_error = true;
+                    return Err(err(format!(
+                        "Unable to resolve REI symbol {pre_alias_symbol} from \
+                         description \"{description}\". Include a matching BUY \
+                         or SELL row for this security in the export."
+                    )));
+                }
             } else {
-                (pre_alias_symbol, String::new())
+                (pre_alias_symbol.clone(), false)
+            };
+
+            let (symbol, orig_symbol_note) = if let Some((alias, aka)) =
+                symbol_aliases.get(resolved_symbol.as_str())
+            {
+                (alias.to_string(), format!("; {resolved_symbol} AKA {aka}"))
+            } else if resolved_from_description {
+                (
+                    resolved_symbol,
+                    format!("; {pre_alias_symbol} resolved from description"),
+                )
+            } else {
+                (resolved_symbol, String::new())
+            };
+
+            let num_shares = reader.get_dec("Quantity")?.abs();
+            let mut amount_per_share = reader.get_dec("Price")?;
+            if action_str == "REI"
+                && amount_per_share.is_zero()
+                && !num_shares.is_zero()
+            {
+                amount_per_share = reader.get_dec("Net Amount")?.abs() / num_shares;
             };
 
             let account_memo = account.memo_str();
+            let description_note = if action_str == "REI" {
+                format!("; Desc: {description}")
+            } else {
+                String::new()
+            };
 
             let b_tx = BrokerTx {
                 security: symbol,
@@ -186,11 +240,14 @@ pub fn sheet_to_txs(
                 trade_date_and_time: trade_date_str_full,
                 settlement_date_and_time: settlement_date_str_full,
                 action,
-                amount_per_share: reader.get_dec("Price")?,
-                num_shares: reader.get_dec("Quantity")?.abs(),
+                amount_per_share,
+                num_shares,
                 commission: reader.get_dec("Commission")?.abs(),
                 currency: Currency::new(reader.get_str("Currency")?.as_str()),
-                memo: account_memo + &orig_symbol_note + &converted_action_note,
+                memo: account_memo
+                    + &orig_symbol_note
+                    + &converted_action_note
+                    + &description_note,
                 exchange_rate: None,
                 row_num: row_num as u32,
                 account: account,
@@ -226,13 +283,71 @@ pub fn sheet_to_txs(
 
     if errors.len() > 0 {
         Err(SheetToTxsErr {
-            txs: Some(txs),
+            txs: if fatal_error { None } else { Some(txs) },
             errors: errors,
             warnings: vec![],
         })
     } else {
         Ok(txs)
     }
+}
+
+fn build_desc_symbol_aliases(sheet: &Range<Data>) -> HashMap<String, String> {
+    let mut rows = sheet.rows();
+    let mut reader = match crate::peripheral::excel::SheetReader::new(&mut rows) {
+        Ok(reader) => reader,
+        Err(_) => return HashMap::new(),
+    };
+
+    let mut desc_symbol_aliases = HashMap::new();
+    for (row_idx, row) in sheet.rows().enumerate().skip(1) {
+        reader.set_row(row, row_idx + 1);
+
+        let Ok(action_raw) = reader.get_str("Action") else {
+            continue;
+        };
+        let action = action_raw.to_uppercase();
+        if !matches!(action.as_str(), "BUY" | "SELL") {
+            // BUY/SELL rows are the only rows that reliably pair Questrade's
+            // security description with the public trading symbol. Cash
+            // activity can reuse similar descriptions with non-security
+            // placeholders, so it must not seed DRIP symbol aliases.
+            continue;
+        }
+
+        let Ok(symbol) = reader.get_str("Symbol") else {
+            continue;
+        };
+        if symbol.is_empty() {
+            continue;
+        }
+
+        let Ok(description) = reader.get_str("Description") else {
+            continue;
+        };
+        let key = normalize_symbol_lookup_desc(&description);
+        if !key.is_empty() {
+            desc_symbol_aliases.entry(key).or_insert(symbol);
+        }
+    }
+
+    desc_symbol_aliases
+}
+
+fn normalize_symbol_lookup_desc(description: &str) -> String {
+    // Keep only the security-name prefix. Questrade appends different
+    // execution/dividend metadata depending on the row type, while the prefix
+    // is the stable part shared by matching BUY/SELL and REI rows.
+    const DESC_END_MARKERS: [&str; 4] =
+        [" REINV@", " WE ACTED AS ", " REC ", " PAY "];
+
+    let mut end = description.len();
+    for marker in DESC_END_MARKERS {
+        if let Some(idx) = description.find(marker) {
+            end = end.min(idx);
+        }
+    }
+    description[..end].trim().to_string()
 }
 
 lazy_static! {
@@ -278,5 +393,208 @@ pub fn extract_questrade_accounts(
             }
             vec![]
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::peripheral::excel::read_xl_data;
+    use rust_decimal::Decimal;
+
+    #[cfg(feature = "xlsx_write")]
+    fn make_questrade_sheet_bytes(rows: &[Vec<&str>]) -> Vec<u8> {
+        use rust_xlsxwriter::Workbook;
+
+        let mut wb = Workbook::new();
+        let sheet = wb.add_worksheet();
+        let headers = [
+            "Transaction Date",
+            "Settlement Date",
+            "Action",
+            "Symbol",
+            "Description",
+            "Quantity",
+            "Price",
+            "Gross Amount",
+            "Commission",
+            "Net Amount",
+            "Currency",
+            "Account #",
+            "Activity Type",
+            "Account Type",
+        ];
+
+        for (col, value) in headers.iter().enumerate() {
+            sheet.write(0, col as u16, *value).unwrap();
+        }
+        for (row_idx, row) in rows.iter().enumerate() {
+            for (col_idx, value) in row.iter().enumerate() {
+                sheet.write((row_idx + 1) as u32, col_idx as u16, *value).unwrap();
+            }
+        }
+
+        wb.save_to_buffer().unwrap()
+    }
+
+    #[cfg(feature = "xlsx_write")]
+    #[test]
+    fn test_rei_rows_convert_to_buys() {
+        let data = make_questrade_sheet_bytes(&[
+            vec![
+                "2026-02-17 12:00:00 AM",
+                "2026-02-19 12:00:00 AM",
+                "REI",
+                "Z491275",
+                "AURORA NORTHERN INCOME ETF SHS REINV@U$42.615 REC 02/11/26 PAY 02/17/26",
+                "14.00000",
+                "0.00000000",
+                "0.00",
+                "0.00",
+                "-596.61",
+                "USD",
+                "11112222",
+                "Dividend reinvestment",
+                "Individual margin",
+            ],
+            vec![
+                "2026-01-09 12:00:00 AM",
+                "2026-01-13 12:00:00 AM",
+                "Buy",
+                "ANIE",
+                "AURORA NORTHERN INCOME ETF SHS WE ACTED AS AGENT",
+                "9.00000",
+                "31.22000000",
+                "-280.98",
+                "0.00",
+                "-280.98",
+                "USD",
+                "11112222",
+                "Trades",
+                "Individual margin",
+            ],
+        ]);
+
+        let range = read_xl_data(data, None).unwrap();
+        let txs = sheet_to_txs(&range, None).unwrap();
+
+        let rei_tx = txs.iter().find(|tx| tx.row_num == 2).unwrap();
+        assert_eq!(rei_tx.security, "ANIE");
+        assert_eq!(rei_tx.action, TxAction::Buy);
+        assert_eq!(rei_tx.amount_per_share, Decimal::new(42615, 3));
+        assert_eq!(rei_tx.num_shares, Decimal::new(14, 0));
+        assert!(rei_tx.memo.contains("resolved from description"));
+        assert!(rei_tx.memo.contains("From REI action."));
+        assert!(rei_tx.memo.contains(
+            "Desc: AURORA NORTHERN INCOME ETF SHS REINV@U$42.615 REC 02/11/26 PAY 02/17/26"
+        ));
+
+        let rei_fx = txs
+            .iter()
+            .find(|tx| tx.security == "USD.FX" && tx.row_num == 2)
+            .unwrap();
+        assert_eq!(rei_fx.action, TxAction::Sell);
+        assert_eq!(rei_fx.num_shares, Decimal::new(59661, 2));
+    }
+
+    #[cfg(feature = "xlsx_write")]
+    #[test]
+    fn test_rei_without_trade_alias_is_fatal() {
+        let data = make_questrade_sheet_bytes(&[
+            vec![
+                "2026-02-17 12:00:00 AM",
+                "2026-02-19 12:00:00 AM",
+                "REI",
+                "Z491275",
+                "AURORA NORTHERN INCOME ETF SHS REINV@U$42.615 REC 02/11/26 PAY 02/17/26",
+                "14.00000",
+                "0.00000000",
+                "0.00",
+                "0.00",
+                "-596.61",
+                "USD",
+                "11112222",
+                "Dividend reinvestment",
+                "Individual margin",
+            ],
+        ]);
+
+        let range = read_xl_data(data, None).unwrap();
+        let err = sheet_to_txs(&range, None).unwrap_err();
+
+        assert!(
+            err.txs.is_none(),
+            "unresolved REI rows must be fatal so no CSV output is written"
+        );
+        assert_eq!(err.errors.len(), 1);
+        let msg = err.errors[0].to_string();
+        assert!(msg.contains("Unable to resolve REI symbol Z491275"));
+        assert!(msg.contains("matching BUY or SELL row"));
+    }
+
+    #[cfg(feature = "xlsx_write")]
+    #[test]
+    fn test_rei_aliases_ignore_non_trade_rows() {
+        let data = make_questrade_sheet_bytes(&[
+            vec![
+                "2026-02-17 12:00:00 AM",
+                "2026-02-19 12:00:00 AM",
+                "REI",
+                "Z491275",
+                "AURORA NORTHERN INCOME ETF SHS REINV@U$42.615 REC 02/11/26 PAY 02/17/26",
+                "14.00000",
+                "0.00000000",
+                "0.00",
+                "0.00",
+                "-596.61",
+                "USD",
+                "11112222",
+                "Dividend reinvestment",
+                "Individual margin",
+            ],
+            vec![
+                "2026-02-17 12:00:00 AM",
+                "2026-02-17 12:00:00 AM",
+                "DIV",
+                "ZPOISON",
+                "AURORA NORTHERN INCOME ETF SHS REC 02/11/26 PAY 02/17/26",
+                "0.00000",
+                "0.00000000",
+                "0.00",
+                "0.00",
+                "10.00",
+                "USD",
+                "11112222",
+                "Dividends",
+                "Individual margin",
+            ],
+            vec![
+                "2026-01-09 12:00:00 AM",
+                "2026-01-13 12:00:00 AM",
+                "Buy",
+                "ANIE",
+                "AURORA NORTHERN INCOME ETF SHS WE ACTED AS AGENT",
+                "9.00000",
+                "31.22000000",
+                "-280.98",
+                "0.00",
+                "-280.98",
+                "USD",
+                "11112222",
+                "Trades",
+                "Individual margin",
+            ],
+        ]);
+
+        let range = read_xl_data(data, None).unwrap();
+        let txs = sheet_to_txs(&range, None).unwrap();
+
+        let rei_tx = txs.iter().find(|tx| tx.row_num == 2).unwrap();
+        assert_eq!(rei_tx.security, "ANIE");
+        assert!(rei_tx.memo.contains("Z491275 resolved from description"));
+        assert!(
+            !txs.iter().any(|tx| tx.security == "ZPOISON"),
+            "non-trade rows must not be used as REI symbol aliases"
+        );
     }
 }


### PR DESCRIPTION
"A Dividend Reinvestment Plan (DRIP) allows you to automatically reinvest your cash dividends to purchase additional shares or fund units of the company that paid you those dividends."

These transactions are recorded as "REI" with an internal identifier instead of the actual symbol, so we need to convert such rows into buys with derived prices and symbol resolution from matching descriptions.

Append the original broker description to the memo field for tracking.