### PR TITLE
Add CSV merge utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,11 @@ path = "src/bin/csv_to_xlsx.rs"
 required-features = [ "xlsx_write" ]
 
 [[bin]]
+name = "csv-merge"
+path = "src/bin/csv_merge.rs"
+required-features = []
+
+[[bin]]
 name = "questrade-statement-fmv"
 path = "src/bin/questrade_statement_fmv.rs"
 required-features = [ "pdf_parse" ]

--- a/src/bin/csv_merge.rs
+++ b/src/bin/csv_merge.rs
@@ -1,0 +1,20 @@
+use acb::util::basic::SError;
+use clap::Parser;
+
+/// A convenience script to merge CSV files to stdout
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+pub struct Args {
+    /// One or more CSV files. Rows are written in the provided order.
+    #[arg(required = true)]
+    pub csv_files: Vec<String>,
+}
+
+fn main() -> Result<(), SError> {
+    let args = Args::parse();
+
+    acb::peripheral::csv_merge_impl::merge_csv_files(
+        &args.csv_files,
+        std::io::stdout(),
+    )
+}

--- a/src/peripheral.rs
+++ b/src/peripheral.rs
@@ -1,5 +1,6 @@
 pub mod acb_config_cmd;
 pub mod broker;
+pub mod csv_merge_impl;
 pub mod sheet_common;
 
 #[cfg(feature = "xlsx_read")]

--- a/src/peripheral/csv_merge_impl.rs
+++ b/src/peripheral/csv_merge_impl.rs
@@ -1,0 +1,94 @@
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+use std::path::Path;
+
+use crate::util::basic::SError;
+
+fn normalize_header(header: &str) -> String {
+    header.trim().to_lowercase()
+}
+
+#[derive(Debug)]
+struct OutputColumn {
+    header: String,
+    normalized_header: String,
+}
+
+pub fn merge_csv_files<P, W>(csv_files: &[P], output: W) -> Result<(), SError>
+where
+    P: AsRef<Path>,
+    W: Write,
+{
+    let mut output_columns = Vec::<OutputColumn>::new();
+    let mut seen_output_columns = HashSet::<String>::new();
+    let mut output_rows = Vec::<Vec<String>>::new();
+
+    for csv_file in csv_files {
+        let csv_path = csv_file.as_ref();
+        let mut reader = csv::ReaderBuilder::new()
+            .has_headers(true)
+            .from_path(csv_path)
+            .map_err(|e| format!("Failed to read {}: {e}", csv_path.display()))?;
+
+        let headers = reader
+            .headers()
+            .map_err(|e| {
+                format!("Failed to read headers from {}: {e}", csv_path.display())
+            })?
+            .clone();
+        let normalized_headers: Vec<String> =
+            headers.iter().map(normalize_header).collect();
+
+        for (header, normalized_header) in headers.iter().zip(&normalized_headers) {
+            if seen_output_columns.insert(normalized_header.clone()) {
+                output_columns.push(OutputColumn {
+                    header: header.to_string(),
+                    normalized_header: normalized_header.clone(),
+                });
+                for row in &mut output_rows {
+                    row.push(String::new());
+                }
+            }
+        }
+
+        for (row_index, record) in reader.records().enumerate() {
+            let record = record.map_err(|e| {
+                format!(
+                    "Failed to read row {} from {}: {e}",
+                    row_index + 2,
+                    csv_path.display()
+                )
+            })?;
+            let mut values = HashMap::<&str, &str>::new();
+            for (normalized_header, value) in
+                normalized_headers.iter().zip(record.iter())
+            {
+                values.entry(normalized_header.as_str()).or_insert(value);
+            }
+
+            let row = output_columns
+                .iter()
+                .map(|col| {
+                    values
+                        .get(col.normalized_header.as_str())
+                        .map(|value| (*value).to_string())
+                        .unwrap_or_default()
+                })
+                .collect();
+            output_rows.push(row);
+        }
+    }
+
+    let mut writer = csv::WriterBuilder::new().has_headers(true).from_writer(output);
+    writer
+        .write_record(output_columns.iter().map(|col| col.header.as_str()))
+        .map_err(|e| format!("Failed to write output header: {e}"))?;
+    for row in output_rows {
+        writer
+            .write_record(row)
+            .map_err(|e| format!("Failed to write output row: {e}"))?;
+    }
+    writer.flush().map_err(|e| format!("Failed to flush output: {e}"))?;
+
+    Ok(())
+}

--- a/tests/csv_merge_test.rs
+++ b/tests/csv_merge_test.rs
@@ -1,0 +1,37 @@
+use acb::peripheral::csv_merge_impl::merge_csv_files;
+
+fn fixture_path(name: &str) -> String {
+    std::path::Path::new("./tests/data/csv_merge")
+        .join(name)
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn test_merge_preserves_first_file_column_order() {
+    let mut output = Vec::new();
+    merge_csv_files(
+        &[
+            fixture_path("all-full-2024-like.csv"),
+            fixture_path("broker1.csv"),
+            fixture_path("broker2.csv"),
+        ],
+        &mut output,
+    )
+    .unwrap();
+    assert_eq!(
+        "\
+security,trade date,settlement date,action,shares,amount/share,commission,split ratio,currency,memo,Exchange Rate
+AAA,2024-01-02,2024-01-04,Buy,3,373.305,1.23,,USD,Broker legacy buy,
+BBB,2024-02-12,2024-02-14,Sell,4,143.21,2.34,,USD,Broker legacy sell,
+CCC,2024-12-04,2024-11-25,Split,,,,4-for-1,,4:1 split,
+FFF,2024-12-20,2024-12-24,Buy,7,71.805,0.45,,USD,Broker margin acct-001,
+DDD,2025-01-03,2025-01-06,Buy,1,48.9968,0.00,,USD,Broker margin acct-001,
+EEE,2025-01-03,2025-01-06,Buy,6,59.0659,0.00,,USD,Broker margin acct-001,
+CCC,2025-02-15,2025-02-15,Buy,115,106.87,0.00,,USD,ESPP,
+CCC,2025-02-19,2025-02-20,Sell,19,104.704737,5.02,,USD,ESPP sell-to-cover,
+",
+        String::from_utf8(output).unwrap()
+    );
+}

--- a/tests/data/csv_merge/all-full-2024-like.csv
+++ b/tests/data/csv_merge/all-full-2024-like.csv
@@ -1,0 +1,5 @@
+security,trade date,settlement date,action,shares,amount/share,commission,split ratio,currency,memo,Exchange Rate
+AAA,2024-01-02,2024-01-04,Buy,3,373.305,1.23,,USD,Broker legacy buy,
+BBB,2024-02-12,2024-02-14,Sell,4,143.21,2.34,,USD,Broker legacy sell,
+CCC,2024-12-04,2024-11-25,Split,,,,4-for-1,,4:1 split,
+FFF,2024-12-20,2024-12-24,Buy,7,71.805,0.45,,USD,Broker margin acct-001,

--- a/tests/data/csv_merge/broker1.csv
+++ b/tests/data/csv_merge/broker1.csv
@@ -1,0 +1,3 @@
+security,trade date,settlement date,action,commission,shares,amount/share,currency,memo
+DDD,2025-01-03,2025-01-06,Buy,0.00,1,48.9968,USD,Broker margin acct-001
+EEE,2025-01-03,2025-01-06,Buy,0.00,6,59.0659,USD,Broker margin acct-001

--- a/tests/data/csv_merge/broker2.csv
+++ b/tests/data/csv_merge/broker2.csv
@@ -1,0 +1,3 @@
+security,trade date,settlement date,action,shares,amount/share,commission,currency,memo
+CCC,2025-02-15,2025-02-15,Buy,115,106.87,0.00,USD,ESPP
+CCC,2025-02-19,2025-02-20,Sell,19,104.704737,5.02,USD,ESPP sell-to-cover


### PR DESCRIPTION
Add a csv-merge binary backed by a reusable library function that merges multiple CSV files in input order.

The merge preserves the first file's column ordering, appends newly discovered columns from later files, and maps row values by normalized header names so broker exports can differ in column order.

Add fixtures and an integration test covering extra columns, missing values, and a broker file with different column ordering.